### PR TITLE
Fixed issue with forced uppercase being applied to non internal types.

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -17,11 +17,13 @@ var MD = require("node-markdown").Markdown,
     * @return {String} The fixed string
     */
     fixType = function(t) {
-        var firstChar      = t.charAt(0),
-            upperFirstChar = firstChar.toUpperCase();
+        if (t.indexOf('.') === -1) {
+            var firstChar      = t.charAt(0),
+                upperFirstChar = firstChar.toUpperCase();
 
-        if (firstChar !== upperFirstChar) {
-            return upperFirstChar + t.substring(1);
+            if (firstChar !== upperFirstChar) {
+                return upperFirstChar + t.substring(1);
+            }
         }
 
         return t;
@@ -137,13 +139,15 @@ YUI.add('doc-builder', function(Y) {
 
     Y.DocBuilder.prototype = {
         _parseCrossLink: function(item, raw) {
-            item = fixType(item);
             var self = this;
             var base = '../',
                 baseName = item,
                 newWin = false,
                 className = 'crosslink';
 
+			if (typeof self.data.classes[item] !== "undefined") {
+				item = fixType(item);
+			}
 
             item = baseItem = Y.Lang.trim(item.replace('{', '').replace('}', ''));
             //Remove Cruft

--- a/lib/docparser.js
+++ b/lib/docparser.js
@@ -16,11 +16,13 @@ YUI.add('docparser', function(Y) {
     * @return {String} The fixed string
     */
     fixType = function(t) {
-        var firstChar      = t.charAt(0),
-            upperFirstChar = firstChar.toUpperCase();
+        if (t.indexOf('.') === -1) {
+            var firstChar      = t.charAt(0),
+                upperFirstChar = firstChar.toUpperCase();
 
-        if (firstChar !== upperFirstChar) {
-            return upperFirstChar + t.substring(1);
+            if (firstChar !== upperFirstChar) {
+                return upperFirstChar + t.substring(1);
+            }
         }
 
         return t;


### PR DESCRIPTION
Upper case was forced on non internal types so "namespace.Class" would become "Namespace.Class" only internal types like "String" or "Number" should be processed.
