### PR TITLE
Fixing typo when parsing @const tag

### DIFF
--- a/lib/docparser.js
+++ b/lib/docparser.js
@@ -512,7 +512,7 @@ Y.log('param name/type/descript missing: ' + stringlog(block), 'warn', 'docparse
 
         // change 'const' to final property
         'const': function(tagname, value, target, block) {
-            target.itemtype = property;
+            target.itemtype = 'property';
             target.name = value;
             target['final'] = '';
         },


### PR DESCRIPTION
If there is a @const tag in the Javascript code the parser breaks because of a typo when setting the itemtype property of the target to property rather than 'property'
