### PR TITLE
parse coffee comment syntax

### DIFF
--- a/lib/docparser.js
+++ b/lib/docparser.js
@@ -66,8 +66,18 @@ YUI.add('docparser', function(Y) {
     REGEX_TYPE = /(.*?)\{(.*?)\}(.*)/,
     REGEX_FIRSTWORD = /^\s*?([^\s]+)(.*)/,
     REGEX_OPTIONAL = /\[(.*?)\]/,
-    REGEX_START_COMMENT = /^\s*\/\*\*/,
-    REGEX_END_COMMENT = /\*\/\s*$/,
+    REGEX_START_COMMENT = {
+      js: /^\s*\/\*\*/,
+      coffee: /^\s*###\*/
+    },
+    REGEX_END_COMMENT = {
+      js: /\*\/\s*$/,
+      coffee: /###\s*$/
+    },
+    REGEX_LINE_HEAD_CHAR = {
+      js: /^\s*\*/,
+      coffee: /^\s*#/
+    },
     REGEX_LINES = /\r\n|\n/,
     REGEX_GLOBAL_LINES = /\r\n|\n/g,
 
@@ -751,6 +761,15 @@ Y.log('param name/type/descript missing: ' + stringlog(block), 'warn', 'docparse
         },
 
         /**
+         * Comment syntax type. 
+         * @attribute syntaxtype
+         * @type String
+         */
+        syntaxtype: {
+            writeOnce: true,
+        },
+
+        /**
          * The map of file names to file content.
          * @attribute filemap
          */
@@ -1065,13 +1084,14 @@ Y.log('param name/type/descript missing: ' + stringlog(block), 'warn', 'docparse
                 parts, part, peek, skip,
                 results = [{tag: 'file', value: file},
                            {tag: 'line', value: line}],
-                starRegex = /^\s*\*/,
-                hasStars  = lines[0] && starRegex.test(lines[0]);
+                syntaxtype = this.get('syntaxtype'),
+                lineHeadCharRegex = REGEX_LINE_HEAD_CHAR[syntaxtype],
+                hasLineHeadChar  = lines[0] && lineHeadCharRegex.test(lines[0]);
 
-// trim leading stars if there are any
-            if (hasStars) {
+// trim leading line head char(star or harp) if there are any
+            if (hasLineHeadChar) {
                 for (i = 0; i < len; i++) {
-                    lines[i] = lines[i].replace(starRegex, '');
+                    lines[i] = lines[i].replace(lineHeadCharRegex, '');
                 }
             }
 
@@ -1132,6 +1152,7 @@ Y.log('param name/type/descript missing: ' + stringlog(block), 'warn', 'docparse
         extract: function(filemap, dirmap) {
             filemap = filemap || this.get('filemap');
             dirmap = dirmap || this.get('dirmap');
+            var syntaxtype = this.get('syntaxtype');
             var commentmap = {};
             Y.each(filemap, function(code, filename) {
 
@@ -1141,12 +1162,12 @@ Y.log('param name/type/descript missing: ' + stringlog(block), 'warn', 'docparse
 
                 for (i = 0; i < len; i++) {
                     line = lines[i];
-                    if(REGEX_START_COMMENT.test(line)) {
+                    if(REGEX_START_COMMENT[syntaxtype].test(line)) {
                         commentlines = [];
 
                         linenum = i + 1;
 
-                        while (i < len && (!REGEX_END_COMMENT.test(line))) {
+                        while (i < len && (!REGEX_END_COMMENT[syntaxtype].test(line))) {
                             commentlines.push(line);
                             i++;
                             line = lines[i];

--- a/lib/help.js
+++ b/lib/help.js
@@ -48,6 +48,7 @@ YUI.add('help', function(Y) {
         "  -h, --help Show this help",
         "  -q, --quiet Supress logging output",
         "  -T, --theme <simple|default> Choose one of the built in themes (default is default)",
+        "  --syntaxtype <js|coffee> Choose comment syntax type (default is js)",
         "  --server <port> Fire up the YUIDoc server for faster API doc developement. Pass optional port to listen on. (default is 3000)",
         "",
         "  <input path> Supply a list of paths (shell globbing is handy here)",

--- a/lib/options.js
+++ b/lib/options.js
@@ -121,6 +121,9 @@ YUI.add('options', function(Y) {
                 case "--quiet":
                     options.quiet = true;
                     break;
+                case "--syntaxtype":
+                    options.syntaxtype = args.shift();
+                    break;
                 default:
                     if (!options.paths) {
                         options.paths = [];

--- a/lib/yuidoc.js
+++ b/lib/yuidoc.js
@@ -43,7 +43,8 @@ YUI.add('yuidoc', function(Y) {
         norecurse: false,
         version: '0.1.0',
         paths: [],
-        themedir: path.join(__dirname,  'themes', 'default')
+        themedir: path.join(__dirname,  'themes', 'default'),
+        syntaxtype: 'js'
     };
 
     /**
@@ -292,6 +293,7 @@ YUI.add('yuidoc', function(Y) {
             this.walk();
 
             var json = this.writeJSON(new Y.DocParser({
+                syntaxtype: self.options.syntaxtype,
                 filemap: self.filemap,
                 dirmap: self.dirmap
             }).parse());

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -13,7 +13,7 @@ ln -sf ./test2 ./test-linked
 wait
 cd ../
 wait
-../node_modules/.bin/yuitest ./parser.js ./builder.js ./options.js
+../node_modules/.bin/yuitest ./parser.js ./parser_coffee.js ./builder.js ./options.js
 
 exit $?
 

--- a/tests/input/coffee/test.coffee
+++ b/tests/input/coffee/test.coffee
@@ -1,0 +1,12 @@
+
+###*
+# The test project
+# @project tester
+# @title The Tester
+# @icon http://a.img
+# @url http://one.url
+# @url http://two.url
+# @author admo
+# @contributor davglass
+# @contributor entropy
+###

--- a/tests/options.js
+++ b/tests/options.js
@@ -210,6 +210,13 @@ suite.add(new YUITest.TestCase({
             './foobar'
         ]);
         Assert.areEqual('./foobar', options.themedir);
+    },
+    'test: --syntaxtype coffee': function() {
+        var options = Y.Options([
+            '--syntaxtype',
+            'coffee'
+        ]);
+        Assert.areEqual('coffee', options.syntaxtype);
     }
 }));
 

--- a/tests/parser_coffee.js
+++ b/tests/parser_coffee.js
@@ -1,0 +1,62 @@
+var YUITest = require('yuitest'),
+    Assert = YUITest.Assert,
+    ArrayAssert = YUITest.ArrayAssert,
+    path = require('path'),
+    fs = require('fs'),
+    Y = require(path.join(__dirname, '../', 'lib', 'index'));
+
+//Move to the test dir before running the tests.
+process.chdir(__dirname);
+
+var existsSync = fs.existsSync || path.existsSync;
+
+var suite = new YUITest.TestSuite({
+    name: 'Coffee Parser Test Suite',
+    setUp: function() {
+        var json = (new Y.YUIDoc({
+            quiet: true,
+            paths: [ 'input/' ],
+            outdir: './out',
+            extension: '.coffee',
+            syntaxtype: 'coffee'
+        })).run();
+
+        this.project = json.project;
+        this.data = json;
+    }
+});
+
+suite.add(new YUITest.TestCase({
+    name: "Project Data",
+    setUp: function() {
+        this.project = suite.project;
+        this.data = suite.data;
+    },
+    findByName: function(name, cl) {
+        var items = this.data.classitems,
+            ret;
+
+        items.forEach(function(i) {
+            if (i.name === name && i.class === cl) {
+                ret = i;
+            }
+        });
+
+        return ret;
+    },
+    'test: project data': function() {
+        Assert.areSame('input/coffee/test.coffee', this.project.file, 'Project data loaded from wrong file');
+        Assert.areSame(2, this.project.line, 'Line number is off');
+        Assert.areSame('The test project', this.project.description, 'Description not set properly');
+        Assert.areSame('The Tester', this.project.title, 'Title not set');
+        Assert.areSame('admo', this.project.author, 'Author not set');
+        Assert.areSame('entropy', this.project.contributor, 'Contributor not set');
+        Assert.areSame('http://a.img', this.project.icon[0], 'Icon not set');
+        Assert.areSame(1, this.project.icon.length, 'Found wring number of icons');
+        Assert.areSame(2, this.project.url.length, 'Found wrong number of urls');
+        Assert.areSame('http://one.url', this.project.url[0], 'URL #1 is wrong');
+        Assert.areSame('http://two.url', this.project.url[1], 'URL #2 is wrong');
+    }
+}));
+
+YUITest.TestRunner.add(suite);


### PR DESCRIPTION
Add CoffeeScript comment syntax support.

set options `--syntaxtype coffee`.

```
$ yuidoc --syntaxtype coffee -e .coffee input
```

CoffeeScript code is this.

```
###*
# The test project
# @project tester
# @title The Tester
# @icon http://a.img
# @url http://one.url
# @url http://two.url
# @author admo
# @contributor davglass
# @contributor entropy
###
```
