### PR TITLE
Fixed a typo under yuidoc.json Fields > YUIDoc Options > ignorePaths

### DIFF
--- a/docs/args/index.mustache
+++ b/docs/args/index.mustache
@@ -207,7 +207,7 @@ See below for <a href="#ex-yui3">more</a> <a href="#ex-yuidoc">examples</a>.
 </tr>
 <tr>
     <td>`ignorePaths`</th>
-    <td>Specifies an array of string paths to ignore when using shell globbing. This only removes top level items from the list to initally scan. Use `exclude` to remove specific directoies..</td>
+    <td>Specifies an array of string paths to ignore when using shell globbing. This only removes top level items from the list to initally scan. Use `exclude` to remove specific directories.</td>
 </tr>
 <tr>
     <td>`exclude`</th>


### PR DESCRIPTION
Fixed a typo under yuidoc.json Fields > YUIDoc Options > ignorePaths:
"directories" was misspelled as "directoies".
