### PR TITLE
Removed deprecated express.createServer() in Y.Server.init()

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -182,7 +182,7 @@ YUI.add('server', function(Y) {
                 path = require('path');
 
 
-            Server.app = express.createServer();
+            Server.app = express();
             //console.log(Server.options);
             var stat = Server.options.themedir || path.join(__dirname, '../', 'themes', 'default');
             Server.app.use(express.static(stat));


### PR DESCRIPTION
express.createServer() is deprecated, express applications no longer inherit from http.Server.
