### PR TITLE
Invert coverage by running ytestrunner under istanbul

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
         "istanbul": "~0.1.27"
     },
     "scripts": {
-        "test": "ytestrunner --coverage --istanbul --save-coverage --include ./tests/options.js --include ./tests/builder.js --include ./tests/parser.js --include ./tests/parser_coffee.js",
-        "posttest": "./scripts/report.js"
+        "test": "istanbul cover --print=both --yui ytestrunner -- --include ./tests/options.js --include ./tests/builder.js --include ./tests/parser.js --include ./tests/parser_coffee.js"
     },
     "preferGlobal": "true",
     "licenses":[


### PR DESCRIPTION
Unfortunately you need to use the undocumented `--yui` flag for this (so it hooks the YUI loader as well). And I plan to take it out and replace it with something else later.

As long as you are willing to make minor changes to the command line when I fix this, you can accept my pull request.

Otherwise what you are doing seems to be the best option for now.
