### PR TITLE
Handle stale localStorage when selecting the default tab in the UI

### DIFF
--- a/themes/default/assets/js/apidocs.js
+++ b/themes/default/assets/js/apidocs.js
@@ -247,6 +247,11 @@ pjax.updateTabState = function (src) {
     } else {
         tab = Y.one('#classdocs .api-class-tab.' + defaultTab);
 
+        // When the `defaultTab` node isn't found, `localStorage` is stale.
+        if (!tab && defaultTab !== 'index') {
+            tab = Y.one('#classdocs .api-class-tab.index');
+        }
+
         if (classTabView.get('rendered')) {
             Y.Widget.getByNode(tab).set('selected', 1);
         } else {


### PR DESCRIPTION
Fixes #121 by gracefully handling when the default tab name stored in `localStorage` is stale by selecting the `"index"` tab instead.
