### PR TITLE
Option to specify how many spaces each tab-space should be converted to in source view

### DIFF
--- a/docs/args/index.mustache
+++ b/docs/args/index.mustache
@@ -225,6 +225,10 @@ See below for <a href="#ex-yui3">more</a> <a href="#ex-yuidoc">examples</a>.
     <td>Specifies the directory in which to place the rendered HTML files and assets.</td>
 </tr>
 <tr>
+    <td>'tabtospace'</th>
+    <td>Specifies the number of spaces each tab character in source code should be converted to when using YUIDoc's source code view. The default is 8.</td>
+</tr>
+<tr>
     <td>`external.data`</th>
     <td>
         Provides a link to an external `data.json` file to merge into the local api docs. 

--- a/docs/args/partials/help.mustache
+++ b/docs/args/partials/help.mustache
@@ -30,6 +30,7 @@ Common Options:
   -q, --quiet Supress logging output
   -T, --theme <simple|default> Choose one of the built in themes (default is default)
   --syntaxtype <js|coffee> Choose comment syntax type (default is js)
+  --tab-to-space <number> Choose how many spaces a single tab space in source code should be converted to in source code view
   --server <port> Fire up the YUIDoc server for faster API doc developement. Pass optional port to listen on. (default is 3000)
   --lint Lint your docs, will print parser warnings and exit code 1 if there are any
 

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -53,6 +53,7 @@ YUI.add('doc-builder', function(Y) {
         if (options.themedir) {
             themeDir = options.themedir;
         }
+
         this.data = data;
         Y.log('Building..', 'info', 'builder');
         this.files = 0;
@@ -1475,8 +1476,13 @@ YUI.add('doc-builder', function(Y) {
                         cb(err);
                         return;
                     }
+
+                    if (typeof self.options.tabspace === 'string') {
+                        str = str.replace(/\t/, self.options.tabspace, 'g');
+                    }
+                    
                     opts.meta.fileData = str;
-                    var view   = new Y.DocView(opts.meta, 'index');
+                    var view = new Y.DocView(opts.meta, 'index');
                     var mainLayout = opts.layouts[layout];
                     self.render('{{>files}}', view, mainLayout, opts.partials, function(err, html) {
                         self.files++;

--- a/lib/options.js
+++ b/lib/options.js
@@ -134,6 +134,9 @@ YUI.add('options', function(Y) {
                 case "--syntaxtype":
                     options.syntaxtype = args.shift();
                     break;
+                case "--tab-to-space":
+                    options.tabtospace = parseInt(args.shift());
+                    break;
                 default:
                     if (!options.paths) {
                         options.paths = [];

--- a/lib/project.js
+++ b/lib/project.js
@@ -45,6 +45,13 @@ YUI.add('project', function(Y) {
                 Y.showHelp();
                 process.exit(1);
             }
+            
+            if (typeof options.tabtospace === 'number') {
+                options.tabspace = '';
+                for (var s = 0; s < options.tabtospace; s++) {
+                    options.tabspace += ' ';
+                }
+            }
 
             return options;
             


### PR DESCRIPTION
Some projects (believe it or not) like to use actual tab spaces instead of expanded spaces to align their code. These projects' source code should not look mis-aligned in YUIDoc's source code view. Previously, the builder was automatically rendering each tab space as 8 spaces. This commit adds the ability for the user to customize this behavior by doing the following:

From command line:
`--tab-to-space <number> number of spaces to convert each tab to`

Or in yuidoc.json:

``` json
"options": {
    "tabtospace": 4
}
```

Documentation .mustache files have been changed to reflect this feature as well.
