### PR TITLE
Whoops, used tilde instead of apostrophe to mark up the args doc

### DIFF
--- a/docs/args/index.mustache
+++ b/docs/args/index.mustache
@@ -225,7 +225,7 @@ See below for <a href="#ex-yui3">more</a> <a href="#ex-yuidoc">examples</a>.
     <td>Specifies the directory in which to place the rendered HTML files and assets.</td>
 </tr>
 <tr>
-    <td>'tabtospace'</th>
+    <td>`tabtospace`</th>
     <td>Specifies the number of spaces each tab character in source code should be converted to when using YUIDoc's source code view. The default is 8.</td>
 </tr>
 <tr>


### PR DESCRIPTION
The documentation site now shows 'tabtospace' instead of `tabtospace`. This commit is a quick fix of that.
