### PR TITLE
Fix use of parseInt when checking tab-to-space setting

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -135,7 +135,7 @@ YUI.add('options', function(Y) {
                     options.syntaxtype = args.shift();
                     break;
                 case "--tab-to-space":
-                    options.tabtospace = parseInt(args.shift());
+                    options.tabtospace = parseInt(args.shift(), 10);
                     if (typeof options.tabtospace === 'number') {
                         options.tabspace = '';
                         for (var s = 0; s < options.tabtospace; s++) {

--- a/tests/options.js
+++ b/tests/options.js
@@ -39,6 +39,57 @@ suite.add(new YUITest.TestCase({
         Assert.areSame(3000, options.port, 'Failed to set default port');
         Assert.isArray(options.paths, 'Failed to set path');
         Assert.areSame('./foo', options.paths[0], 'Failed to set path after empty --server');
+    },
+    'test: tab-to-space': function() {
+        var options, value;
+
+        // Test that --tab-to-space gives the correct number.
+        // It uses parseInt so check numbers which look like octals too.
+
+        value = 12;
+        options = Y.Options([
+            '--tab-to-space',
+            '0' + value
+        ]);
+        Assert.areSame(value, options.tabtospace);
+        Assert.areSame(value, options.tabspace.length);
+
+        options = Y.Options([
+            '--tab-to-space',
+            '' + value
+        ]);
+        Assert.areSame(value, options.tabtospace);
+        Assert.areSame(value, options.tabspace.length);
+
+        options = Y.Options([
+            '--tab-to-space',
+            value
+        ]);
+        Assert.areSame(value, options.tabtospace);
+        Assert.areSame(value, options.tabspace.length);
+
+        value = 10;
+        options = Y.Options([
+            '--tab-to-space',
+            '0' + value
+        ]);
+        Assert.areSame(value, options.tabtospace);
+        Assert.areSame(value, options.tabspace.length);
+
+        options = Y.Options([
+            '--tab-to-space',
+            '' + value
+        ]);
+        Assert.areSame(value, options.tabtospace);
+        Assert.areSame(value, options.tabspace.length);
+
+        options = Y.Options([
+            '--tab-to-space',
+            value
+        ]);
+        Assert.areSame(value, options.tabtospace);
+        Assert.areSame(value, options.tabspace.length);
+
     }
 }));
 


### PR DESCRIPTION
Just noticed this whilst taking a look at lib/options.js and thought I'd submit a fix. I doubt anyone has actually hit it, but it's a bug none-the-less.
