### PR TITLE
Ensure that validatePaths can process arrays of globs

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -368,36 +368,39 @@ Y.getDirs = getDirs;
 */
 
 var validatePaths = function(paths, ignore) {
+    var newpaths = [];
     //Shortcut the *, . & ./ shortcuts that shall globbing fixes for us
     if (paths === '*' || paths === '.' || paths === './') {
         paths = [process.cwd()];
     }
-    if (!paths || !paths.forEach) {
-        var glob = paths || '';
+
+    // Ensure that we always have an array of some kind.
+    paths = paths || [];
+    if (!Y.Lang.isArray(paths)) {
+        paths = [ paths ];
+    }
+    paths.forEach(function(path) {
+        var glob = path || '';
 
         if (process.platform === 'win32') {
-            if (paths) {
-                glob = paths.replace(/\//g, '\\\\');
-            }
+            glob = path.replace(/\//g, '\\\\');
         }
 
-        paths = [];
         var glob_paths = getDirs('.');
         glob_paths.forEach(function(dir) {
             if (minimatch(dir, glob, { period: true })) {
-                paths.push(dir);
+                newpaths.push(dir);
             }
         });
-    }
-    if (paths.forEach) {
-        paths.forEach(function(p) {
-            try {
-                if (!Y.Files.isDirectory(p)) {
-                    throw('Path not a directory: ' + p);
-                }
-            } catch (e) {}
-        });
-    }
+    });
+    paths = newpaths;
+    paths.forEach(function(p) {
+        try {
+            if (!Y.Files.isDirectory(p)) {
+                throw('Path not a directory: ' + p);
+            }
+        } catch (e) {}
+    });
     if (!paths || !paths.forEach) {
         throw('Paths should be an array of paths');
     }

--- a/tests/input/globbing/deep/deep/sub/yui/src/example/example.js
+++ b/tests/input/globbing/deep/deep/sub/yui/src/example/example.js
@@ -1,0 +1,1 @@
+// Sample content

--- a/tests/input/globbing/deep/shallow/yui/src/example/example.js
+++ b/tests/input/globbing/deep/shallow/yui/src/example/example.js
@@ -1,0 +1,1 @@
+// Sample content

--- a/tests/input/globbing/shallow/yui/src/example/example.js
+++ b/tests/input/globbing/shallow/yui/src/example/example.js
@@ -1,0 +1,1 @@
+// Sample content

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -36,4 +36,44 @@ suite.add(new YUITest.TestCase({
   }
 }));
 
+suite.add(new YUITest.TestCase({
+  name: 'validatePaths',
+  'test: path globs': function() {
+        var options;
+
+        process.chdir(path.join(__dirname, 'input/globbing'));
+
+        // Simulate a path provided by a configuration...
+        // first with a String path
+        options = {
+            paths: '**/yui/src/*'
+        };
+        options = Y.Project.init(options);
+
+        Assert.isArray(options.paths, 'Failed to set path');
+        Assert.areSame(3, options.paths.length, 'Failed to retrieve all path options');
+
+        // then with an Array of path
+        options = {
+            paths: [
+                '**/yui/src/*'
+            ]
+        };
+        options = Y.Project.init(options);
+
+        Assert.isArray(options.paths, 'Failed to set path');
+        Assert.areSame(3, options.paths.length, 'Failed to retrieve all path options');
+
+
+        // Test with a path as passed to Y.Options
+        options = Y.Options([
+            '**/yui/src/*'
+        ]);
+        options = Y.Project.init(options);
+
+        Assert.isArray(options.paths, 'Failed to set path');
+        Assert.areSame(3, options.paths.length, 'Failed to retrieve all path options');
+  }
+}));
+
 YUITest.TestRunner.add(suite);


### PR DESCRIPTION
I discovered that, whilst you can specify a globbed path containing *\* as a String in yuidoc.json (e.g. "path": "**/yui/src/*"), it's not possible to use an array of globbed paths (e.g. "path": [ "**/yui/src/_", "__/example/src/_" ]), or to use the *\* pattern in the CLI.

Looking into it, the String works because minimatch is only used to expand the *\* pattern if the value is not an array.
Ensuring that paths is always an array and then performing the minimatch on all members of the array has the desired effect.
