### PR TITLE
Use Marked instead of node-markdown

### DIFF
--- a/docs/args/index.mustache
+++ b/docs/args/index.mustache
@@ -235,6 +235,13 @@ See below for <a href="#ex-yui3">more</a> <a href="#ex-yuidoc">examples</a>.
         For more information, refer to the <a href="#external-data">external data example</a>.
     </td>
 </tr>
+<tr>
+    <td>`markdown`</td>
+    <td>
+        Options to pass to Marked, the Markdown compiler used to compile API descriptions. 
+        See the <a href="https://github.com/chjj/marked#options">Marked readme</a> for details.
+    </td>
+</tr>
 </table>
 
 <h3 id="ex-yui3">Example: YUI 3 Library API </h3>

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -3,11 +3,10 @@ Copyright (c) 2011, Yahoo! Inc. All rights reserved.
 Code licensed under the BSD License:
 http://yuilibrary.com/license/
 */
-var MD = require("node-markdown").Markdown,
+var marked = require("marked"),
     fs = require('graceful-fs'),
     noop = function() {},
     path = require('path'),
-    DEFAULT_RETURN_TAGS = 'code|em|strong|span|a|pre|dl|dd|dt|ul|li|ol',
     TEMPLATE;
 
 /**
@@ -139,16 +138,17 @@ YUI.add('doc-builder', function(Y) {
         * @method markdown
         * @private
         * @param {String} md The Markdown string to parse
-        * @param {Boolean} def Only allow default set of HTML tags
-        * @param {Array} tags An array of tags to allow
         * @return {HTML} The rendered HTML
         */
-        markdown: function(md, def, tags) {
-            html = MD(md, def, tags);
+        markdown: function(md) {
+            html = marked(md, this.options.markdown);
             //Only reprocess if helpers were asked for
             if (this.options.helpers || (html.indexOf('{{#crossLink') > -1)) {
                 //console.log('MD: ', html);
                 try {
+                    // marked auto-escapes quotation marks (and unfortunately
+                    // does not expose the escaping function)
+                    html = html.replace(/&quot;/g, "\"");
                     html = (Y.Handlebars.compile(html))({});
                 } catch (hError) {
                     //Remove all the extra escapes
@@ -436,18 +436,6 @@ YUI.add('doc-builder', function(Y) {
             });
         },
         /**
-        * The default tags to use in return descriptions (for Markdown).
-        * @property defaultReturnTags
-        * @type String
-        */
-        defaultReturnTags: DEFAULT_RETURN_TAGS,
-        /**
-        * The default tags to use in params descriptions (for Markdown).
-        * @property defaultTags
-        * @type String
-        */
-        defaultTags: 'p|' + DEFAULT_RETURN_TAGS,
-        /**
         * File counter
         * @property files
         * @type Number
@@ -656,7 +644,7 @@ YUI.add('doc-builder', function(Y) {
                             a.description = self.markdown(a.description);
                         }
                         if (a.example) {
-                            a.example = self.markdown(a.example, true, self.defaultTags);
+                            a.example = self.markdown(a.example);
                         }
                         a = self.addFoundAt(a);
 
@@ -677,7 +665,7 @@ YUI.add('doc-builder', function(Y) {
                         }
                         if (k === 'description' || k === 'example') {
                             if (k1 === 'return') {
-                                o[k1][k] = self.markdown(v, true, self.defaultReturnTags);
+                                o[k1][k] = self.markdown(v);
                             } else if (v.forEach || (v instanceof Object)) {
                                 o[k1][k] = self.augmentData(v);
                             } else {

--- a/output/args/index.html
+++ b/output/args/index.html
@@ -293,6 +293,13 @@ See below for <a href="#ex-yui3">more</a> <a href="#ex-yuidoc">examples</a>.
         For more information, refer to the <a href="#external-data">external data example</a>.
     </td>
 </tr>
+<tr>
+    <td><code>markdown</code></td>
+    <td>
+        Options to pass to Marked, the Markdown compiler used to compile API descriptions. 
+        See the <a href="https://github.com/chjj/marked#options">Marked readme</a> for details.
+    </td>
+</tr>
 </table>
 
 <h3 id="ex-yui3">Example: YUI 3 Library API </h3>

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
         { "name": "Pat Cavit", "email": "pcavit@gmail.com" },
         { "name": "Kazuhito Hokamura", "email": "k.hokamura@gmail.com" },
         { "name": "prodaea", "email": "rlee@etherealnation.net" },
-        { "name": "Wei Wang", "email": "weiwang85@gmail.com" }
+        { "name": "Wei Wang", "email": "weiwang85@gmail.com" },
+        { "name": "Thomas Boyt", "email": "me@thomasboyt.com" }
     ],
     "engines": {
         "node" : ">=0.4.0"
@@ -34,7 +35,7 @@
     "dependencies": {
         "yui": "3.9.1",
         "rimraf": "~2.0.0",
-        "node-markdown": "~0.1.0",
+        "marked": "~0.2.8",
         "minimatch": "~0.2.11",
         "graceful-fs": ">=1.1.1",
         "express": "~2.5.0"

--- a/tests/builder.js
+++ b/tests/builder.js
@@ -30,7 +30,10 @@ var suite = new YUITest.TestSuite({
             outdir: './out',
             helpers: [
                 path.join(__dirname, 'lib/davglass.js')
-            ]
+            ],
+            markdown: {
+                langPrefix: "language-"
+            }
         };
         var json = (new Y.YUIDoc(options)).run();
 
@@ -157,6 +160,21 @@ suite.add(new YUITest.TestCase({
 
             Assert.isObject(method, 'Failed to find inherited method');
             Assert.isTrue((method.description.indexOf('DAVGLASS_WAS_HERE::Foo') > 0), 'Helper failed to parse');
+        }, item);
+    },
+
+    'test: markdown options': function() {
+        var item = suite.data.classes['mywidget.SuperWidget'];
+        Assert.isObject(item, 'Failed to parse class');
+        suite.builder.renderClass(function(html, view, opts) {
+            var method;
+            opts.meta.methods.forEach(function(i) {
+                if (i.name === 'getTargets3' && i.class === 'mywidget.SuperWidget') {
+                    method = i;
+                }
+            });
+
+            Assert.isTrue((method.description.indexOf('language-javascript') > 0), 'Markdown options were not applied');
         }, item);
     }
 }));

--- a/tests/input/inherit/examplemodule.js
+++ b/tests/input/inherit/examplemodule.js
@@ -42,6 +42,25 @@ YUI.add('examplemodule', function (Y) {
                 *     var bar;
                 *
                 */
+
+                /**
+                * Overwritten method see {{#crossLink "mywidget.SuperWidget"}}{{/crossLink}}
+                * also see {{#crossLink "mywidget.SuperWidget/myMethod"}}{{/crossLink}}
+                * This is also a test {{#davglass "Foo"}}{{/davglass}}
+                *
+                * ```javascript
+                *
+                * var test = "hello from a code block!";
+                *
+                * ```
+                *
+                * @method getTargets3
+                * @example
+                *
+                *     var bar;
+                *
+                */
+
                 /**
                 * Override Attribute
                 * @attribute focused2


### PR DESCRIPTION
Closes #155.

One warning: Marked doesn't support the "tag whitelist" ability of node-markdown. Still, while it was available as a parameter to pass to `.markdown()`, I couldn't find anywhere this whitelist was set to anything other than the default, so it seemed unnecessary.
