### PR TITLE
Add rest parameters syntax for multiple params

### DIFF
--- a/docs/syntax/index.mustache
+++ b/docs/syntax/index.mustache
@@ -656,8 +656,8 @@ ATTRS[RENDERED] = {
         <ul>
             <li>`[name]` &mdash; optional parameter</li>
             <li>`[name=foo]` &mdash; default value is foo</li>
-            <li>`name*` &mdash; placeholder for 1..n args</li>
-            <li>`[name]*` &mdash; placeholder for 0..n args</li>
+            <li>`...name` &mdash; placeholder for 1..n args</li>
+            <li>`[...name]` &mdash; placeholder for 0..n args</li>
         </ul>
 
         <p>As shown in the example, you can also nest `@param` tags. 

--- a/lib/docparser.js
+++ b/lib/docparser.js
@@ -212,7 +212,7 @@ YUI.add('docparser', function (Y) {
             //   "type": "string",
             //   "optional": true, // [surroundedbybrackets]
             //   "optdefault": "if specified, this is always string to avoid syntax errors @TODO",
-            //   "multiple": true // endswith*
+            //   "multiple": true // endswith* or ...startswith
             // }
             // ],
             // @param {type} name description    -or-
@@ -310,6 +310,14 @@ YUI.add('docparser', function (Y) {
                             }
                         }
                     }
+                }
+
+                // This should run after the check for optional parameters
+                // and before the check for child parameters
+                // because the signature for 0..n params is [...args]
+                if (name.substr(0, 3) === '...') {
+                    multiple = true;
+                    name = name.substr(3);
                 }
 
                 // parse object.prop, indicating a child property for object

--- a/tests/input/test/test.js
+++ b/tests/input/test/test.js
@@ -77,6 +77,22 @@
  */
 
 /**
+test alternative 1..n param with ...args
+
+@method testrestparam1n
+@param {String} ...multiple my desc
+@returns something without a type
+**/
+
+/**
+test alternative 0..n param with ...args
+
+@method testrestparam0n
+@param {String} [...multiple] my desc
+@returns something without a type
+**/
+
+/**
 Test newlines before descriptions.
 
 @method testNewlineBeforeDescription

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -260,7 +260,7 @@ suite.add(new YUITest.TestCase({
         Assert.areSame('String', item2["return"].type, 'Type should not be missing');
     },
     'test: parameter parsing': function () {
-        var item, item2;
+        var item, item2, item3, item4;
         item = this.findByName('testoptional', 'myclass');
         Assert.isArray(item.params, 'Params should be an array');
         Assert.areSame(5, item.params.length, 'Failed to parse all 5 parameters');
@@ -294,6 +294,20 @@ suite.add(new YUITest.TestCase({
         Assert.isTrue(item2.params[0].multiple, 'Multiple not set');
         Assert.isUndefined(item2["return"].type, 'Type should be missing');
 
+        item3 = this.findByName('testrestparam0n', 'myclass');
+        Assert.isArray(item3.params, 'Params should be an array');
+        Assert.areSame(1, item3.params.length, 'Failed to parse all 5 parameters');
+        Assert.isTrue(item3.params[0].optional, 'Optional not set');
+        Assert.isTrue(item3.params[0].multiple, 'Multiple not set');
+        Assert.isUndefined(item3['return'].type, 'Type should be missing');
+
+        item4 = this.findByName('testrestparam1n', 'myclass');
+        Assert.isArray(item4.params, 'Params should be an array');
+        Assert.areSame(1, item4.params.length, 'Failed to parse all 5 parameters');
+        Assert.isUndefined(item4.params[0].optional, 'Optional should not be set');
+        Assert.isTrue(item4.params[0].multiple, 'Multiple not set');
+        Assert.isUndefined(item4['return'].type, 'Type should be missing');
+
         item = this.findByName('testNewlineBeforeDescription', 'myclass');
         Assert.isArray(item.params, 'Params should be an array.');
         Assert.areSame(2, item.params.length, 'Should parse two params.');
@@ -315,10 +329,10 @@ suite.add(new YUITest.TestCase({
     'test: indented return description': function () {
         var item = this.findByName('testNewlineBeforeDescription', 'myclass');
 
-        Assert.areSame('Boolean', item.return.type, 'Type should be correct.');
+        Assert.areSame('Boolean', item['return'].type, 'Type should be correct.');
         Assert.areSame(
             'Sometimes true, sometimes false.\nNobody knows!',
-            item.return.description,
+            item['return'].description,
             'Description indentation should be normalized to the first line.'
         );
     },


### PR DESCRIPTION
Hi!

Rest parameter syntax is coming in EcmaScript 6 (already in Firefox Nightly!). It looks like this:

``` JavaScript
function foo(param1, ...args) {
  // args is an array
}
```

I think it makes sense to use this syntax instead of YUIDoc's `*` for multiple parameters. It's easier to remember (I sometimes confuse it with `Type[]`) and maybe some day we'll be using it in real code. This pull request updates the docs to use `...params`, and adds the option for `@param {Type} ...params` and `@param {Type} [...params].`

I added tests for this feature but I can't seem to run them from the command line. Is there anything else I should do besides running `node tests\parser.js`?
