### PR TITLE
making configurable yuiseedurl and yuigridsurl

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -459,7 +459,8 @@ YUI.add('doc-builder', function(Y) {
                     yuiSeedUrl: 'http://yui.yahooapis.com/3.5.0/build/yui/yui-min.js',
                     yuiGridsUrl: 'http://yui.yahooapis.com/3.5.0/build/cssgrids/cssgrids-min.css'
                 }
-            };
+            },
+            self = this;
             if (!this._meta) {
                 try {
                     var meta,
@@ -477,19 +478,29 @@ YUI.add('doc-builder', function(Y) {
 
                     if (meta) {
                         obj.meta = meta;
-                        this._meta = meta;
+                        self._meta = meta;
                     }
                 } catch (e) {
                     console.error('Error', e);
                 }
             } else {
-                obj.meta = this._meta;
+                obj.meta = self._meta;
             }
+
+            //Making yuiSeedUrl and yuiGridsUrl configurable 
+            if(this.options.yuiSeedUrl){
+              obj.meta.yuiSeedUrl = self.options.yuiSeedUrl;  
+            }
+
+            if(this.options.yuiGridsUrl){
+              obj.meta.yuiGridsUrl = self.options.yuiGridsUrl;  
+            }
+
             Y.each(this.data.project, function(v, k) {
                 var key = k.substring(0, 1).toUpperCase() + k.substring(1, k.length);
                 obj.meta['project' + key] = v;
             });
-            return obj
+            return obj;
         },
         /**
         * Populate the meta data for classes

--- a/lib/help.js
+++ b/lib/help.js
@@ -52,6 +52,8 @@ YUI.add('help', function(Y) {
         "  --syntaxtype <js|coffee> Choose comment syntax type (default is js)",
         "  --server <port> Fire up the YUIDoc server for faster API doc developement. Pass optional port to listen on. (default is 3000)",
         "  --lint Lint your docs, will print parser warnings and exit code 1 if there are any",
+        "  --yuigridssurl The place for fetching yuiGridsUrl source",
+        "  --yuiSeedUrl The place for fetching yuiSeedUrl source",
         "",
         "  <input path> Supply a list of paths (shell globbing is handy here)",
         "",

--- a/lib/options.js
+++ b/lib/options.js
@@ -143,6 +143,13 @@ YUI.add('options', function(Y) {
                         }
                     }
                     break;
+                //Making yuiSeedUrl and yuiGridsUrl configurable  
+                case "--yuigridsurl":
+                    options.yuiGridsUrl = args.shift();
+                    break;
+                case "--yuiseedurl":
+                    options.yuiSeedUrl = args.shift();
+                    break;
                 default:
                     if (!options.paths) {
                         options.paths = [];


### PR DESCRIPTION
Sometimes we can need a different yuiseedurl or yuigridsurl.  For example, if we are working in a local network without internet access.
