### PR TITLE
Change lint so that process only exits on failure.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -34,6 +34,9 @@ if (options.server) {
 } else {
 
     var json = (new Y.YUIDoc(options)).run();
+    if (json === null) {
+        return;
+    }
     options = Y.Project.mix(json, options);
 
     if (!options.parseOnly) {

--- a/lib/yuidoc.js
+++ b/lib/yuidoc.js
@@ -335,6 +335,7 @@ YUI.add('yuidoc', function(Y) {
 
             if (this.options.lint) {
                 this.lint(json.warnings);
+                return null;
             }
 
             /**


### PR DESCRIPTION
When using grunt-contrib-yuidoc with the lint option, the lint exits the process, ending the Grunt build even on success. This change only exits the process when an error is detected in the linting.
