### PR TITLE
Fix syntax highlighting for markdown blocks

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -744,7 +744,7 @@ YUI.add('doc-builder', function(Y) {
         _parseCode: function (html) {
             html = html || '';
             //html = html.replace(/<pre><code>/g, '<pre class="code"><code class="prettyprint">');
-            html = html.replace(/<pre><code>/g, '<pre class="code prettyprint"><code>');
+            html = html.replace(/<pre><code/g, '<pre class="code prettyprint"><code');
             return html;
         },
         /**


### PR DESCRIPTION
The regex that was adding the `prettyprint` class to the `<pre>` blocks didn't take into account a `<code>` block that had attributes (which Marked generates). This meant that Markdown syntax blocks weren't getting correctly parsed & pretty-printed. This PR fixes that with a more forgiving regex :)

(cc @stefanpenner, who notified me that it was broken)
