### PR TITLE
Update dependency versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "marked": "~0.2.8",
         "minimatch": "~0.2.11",
         "graceful-fs": "2.x",
-        "express": "3.4.x"
+        "express": "~3.1.2"
     },
     "devDependencies": {
         "ytestrunner": "~0.3.3",


### PR DESCRIPTION
Many of `yuidoc`'s dependencies are getting quite long in the tooth. No tests fail after these updates, but I'm running some locally linked tests using other tools that consume yuidocjs to verify.
