### PR TITLE
[fixes #210] adding support for `abstract` classes

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -637,6 +637,9 @@ YUI.add('doc-builder', function(Y) {
                         if (a.final === '') {
                             a.final = true;
                         }
+                        if (a.abstract === '') {
+                            a.abstract = true;
+                        }
                         if (!a.description) {
                             a.description = ' ';
                         } else {
@@ -661,6 +664,9 @@ YUI.add('doc-builder', function(Y) {
                     i = self.addFoundAt(i);
                     Y.each(i, function(v, k) {
                         if (k === 'final') {
+                            o[k1][k] = true;
+                        }
+                        if (k === 'abstract') {
                             o[k1][k] = true;
                         }
                         if (k === 'description' || k === 'example') {
@@ -1216,6 +1222,9 @@ YUI.add('doc-builder', function(Y) {
                             }
                             if (i.final === '') {
                                 i.final = true;
+                            }
+                            if (i.abstract === '') {
+                                i.abstract = true;
                             }
                             if (i.example && i.example.length) {
                                 if (i.example.forEach) {

--- a/lib/docparser.js
+++ b/lib/docparser.js
@@ -87,6 +87,7 @@ YUI.add('docparser', function(Y) {
         'chainable': 1,
         'extends': 1,
         'final': 1,
+        'abstract': 1,
         'static': 1,
         'optional': 1,
         'required': 1
@@ -131,6 +132,7 @@ YUI.add('docparser', function(Y) {
         "extends", // pseudo inheritance
         "file", // file name (used by the parser)
         "final", // not meant to be changed
+        "abstract", // whether the class is abstract or not
         "fireonce",  // bool, YUI custom event config allows
         "for", // used to change class context
         "global", // declare your globals
@@ -522,6 +524,7 @@ YUI.add('docparser', function(Y) {
             target.itemtype = 'property';
             target.name = value;
             target['final'] = '';
+            target['abstract'] = '';
         },
 
         // supported classitems

--- a/tests/input/charts/AxisType.js
+++ b/tests/input/charts/AxisType.js
@@ -4,6 +4,7 @@
  * @module charts
  * @class AxisType
  * @constructor
+ * @abstract
  * @extends Axis
  */
 Y.AxisType = Y.Base.create("baseAxis", Y.Axis, [], {

--- a/themes/default/assets/css/main.css
+++ b/themes/default/assets/css/main.css
@@ -568,6 +568,7 @@ kbd .cmd { font-family: Monaco, Helvetica; }
 .apidocs .flag.chainable { background: #46ca3b; }
 .apidocs .flag.protected { background: #9b86fc; }
 .apidocs .flag.private { background: #fd6b1b; }
+.apidocs .flag.abstract { background: #fd6b1b; }
 .apidocs .flag.async { background: #356de4; }
 .apidocs .flag.required { background: #e60923; }
 

--- a/themes/default/partials/classes.handlebars
+++ b/themes/default/partials/classes.handlebars
@@ -1,4 +1,4 @@
-<h1>{{name}} Class</h1>
+<h1>{{name}} Class{{#if abstract}} <span class="flag abstract">abstract</span>{{/if}}</h1>
 <div class="box meta">
     {{#if uses}}
         <div class="uses">

--- a/themes/simple/partials/classes.handlebars
+++ b/themes/simple/partials/classes.handlebars
@@ -1,4 +1,4 @@
-<h4>Class {{moduleName}}</h4>
+<h4>Class {{moduleName}}{{#if abstract}} <code>abstract</code>{{/if}}</h4>
 {{#if uses}}
     Uses:
     {{#each uses}}


### PR DESCRIPTION
This PR adds support for abstract classes, marking them with a flag:

```
/**
 * AxisType is an abstract class that manages the data for an axis.
 *
 * @module charts
 * @class AxisType
 * @constructor
 * @abstract
 * @extends Axis
 */
Y.AxisType = Y.Base.create("baseAxis", Y.Axis, [], {
});
```
