### PR TITLE
.pc-only and .mac-only CSS/JS absent in distributed themes

### DIFF
--- a/themes/default/assets/css/main.css
+++ b/themes/default/assets/css/main.css
@@ -781,3 +781,11 @@ kbd .cmd { font-family: Monaco, Helvetica; }
     font-weight: bold;
 }
 
+/* -- Platform/OS-specific Styles ------------------------------------------- */
+.mac-only, .pc-only { visibility: hidden; }
+
+.pc .mac-only,
+.mac .pc-only { display: none; }
+
+.mac .mac-only,
+.pc .pc-only { visibility: visible; }

--- a/themes/default/assets/js/ua.js
+++ b/themes/default/assets/js/ua.js
@@ -1,0 +1,33 @@
+// Quick and dirty platform/os sniff, used only to influence non-critical
+// design elements in CSS.
+(function () {
+    var ua       = navigator.userAgent,
+        os       = '',
+        platform = '';
+
+    if (/windows/i.test(ua)) {
+        platform = 'pc';
+        os       = 'win';
+    } else if (/macintosh/i.test(ua)) {
+        platform = 'mac';
+        os       = 'osx';
+    } else if (/ios/i.test(ua)) {
+        os = 'ios';
+
+        if (/(?:iphone|ipod)/i.test(ua)) {
+            platform = 'iphone mac';
+        } else if (/ipad/i.test(ua)) {
+            platform = 'ipad mac';
+        }
+    } else if (/linux/i.test(ua)) {
+        if (/android/i.test(ua)) {
+            platform = 'android pc';
+        } else {
+            platform = 'pc';
+        }
+
+        os = 'linux';
+    }
+
+    document.documentElement.className += ' ' + platform + ' ' + os;
+}());

--- a/themes/default/layouts/main.handlebars
+++ b/themes/default/layouts/main.handlebars
@@ -45,6 +45,7 @@
 </div>
 <script src="{{projectAssets}}/vendor/prettify/prettify-min.js"></script>
 <script>prettyPrint();</script>
+<script src="{{projectAssets}}/js/ua.js"></script>
 <script src="{{projectAssets}}/js/yui-prettify.js"></script>
 <script src="{{projectAssets}}/../api.js"></script>
 <script src="{{projectAssets}}/js/api-filter.js"></script>


### PR DESCRIPTION
It's fine on yuilibrary.com, but missing when built using yuidoc so you get a few strange UI effects:
![mac_and_pc](https://f.cloud.github.com/assets/370047/2523085/0494c054-b4cc-11e3-8579-0fb0941bf419.png)

Seems to be added by http://yuilibrary.com/combo/js?main.js which obviously isn't included in the yuidoc default theme.
