### PR TITLE
Added theme compare before copying assets

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -1618,10 +1618,13 @@ YUI.add('doc-builder', function (Y) {
                     if (!Y.Files.isDirectory(path.join(self.options.outdir, 'assets'))) {
                         fs.mkdirSync(path.join(self.options.outdir, 'assets'), 0777);
                     }
-                    Y.Files.copyAssets([
-                            path.join(DEFAULT_THEME, 'assets'),
-                            path.join(themeDir, 'assets')
-                        ],
+                    var defaultThemePath = fs.realpathSync(path.join(DEFAULT_THEME, 'assets'));
+                    var currentThemePath = fs.realpathSync(path.join(themeDir, 'assets'));
+                    var sourceFolders = [path.join(DEFAULT_THEME, 'assets')];
+                    if (currentThemePath !== defaultThemePath) {
+                        sourceFolders.push(path.join(themeDir, 'assets'));
+                    }
+                    Y.Files.copyAssets(sourceFolders,
                         path.join(self.options.outdir, 'assets'),
                         false,
                         function () {


### PR DESCRIPTION
Added a check to compare the current theme's absolute path with the default theme's absolute path.  If they are the same path then only copy the default theme's files to the output folder and skip the unnecessary copy of the current theme.  This resolved an issue where our antivirus software would occasionally lock the copied files after the first copy and cause the second unnecessary copy to fail.
