### PR TITLE
fixed wrong "this" in parsedir(), fixed #242

### DIFF
--- a/lib/docparser.js
+++ b/lib/docparser.js
@@ -1244,7 +1244,7 @@ YUI.add('docparser', function (Y) {
                 digestname,
                 digester,
                 host;
-
+            var self = this
             // Y.log(block);
             Y.each(block, function (tag) {
                 var name = trim(tag.tag),
@@ -1257,16 +1257,16 @@ YUI.add('docparser', function (Y) {
                 }
 
                 if (tag && tag.tag) {
-                    if (!(name in this.knowntags)) {
+                    if (!(name in self.knowntags)) {
                         if (name in CORRECTIONS) {
-                            this.warnings.push({
+                            self.warnings.push({
                                 message: 'replacing incorrect tag: ' + name + ' with ' + CORRECTIONS[name],
                                 line: stringlog(block)
                             });
                             Y.log('replacing incorrect tag: ' + name + ' with ' + CORRECTIONS[name] + ': ' + stringlog(block), 'warn', 'docparser');
                             name = CORRECTIONS[name];
                         } else {
-                            this.warnings.push({
+                            self.warnings.push({
                                 message: 'unknown tag: ' + name,
                                 line: stringlog(block)
                             });
@@ -1275,12 +1275,12 @@ YUI.add('docparser', function (Y) {
                     }
 
                     digestname = name;
-                    if (digestname in this.digesters) {
-                        digester = this.digesters[digestname];
+                    if (digestname in self.digesters) {
+                        digester = self.digesters[digestname];
                         if (Lang.isString(digester)) {
-                            digester = this.digesters[digester];
+                            digester = self.digesters[digester];
                         }
-                        ret = digester.call(this, name, value, target, block);
+                        ret = digester.call(self, name, value, target, block);
                         host = host || ret;
                     } else {
                         target[name] = value;

--- a/lib/yuidoc.js
+++ b/lib/yuidoc.js
@@ -141,8 +141,9 @@ YUI.add('yuidoc', function (Y) {
          * @private
          */
         walk: function () {
+            var self = this
             Y.each(this.options.paths, function (dir) {
-                this.parsedir(dir);
+                self.parsedir(dir);
             }, this);
         },
 


### PR DESCRIPTION
yuidoc did not worked from grunt-contrib-yuidoc die to wrong "this" in each() callbacks. Replaced them with "var self=this"

Error log is in issue #242
