### PR TITLE
Allow a base url for external links

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -399,8 +399,14 @@ YUI.add('doc-builder', function (Y) {
             var stack = new Y.Parallel();
             info.data.forEach(function (i) {
                 var base;
+                if (typeof i === 'object') {
+                    base = i.base;
+                    i = i.json;
+                }
                 if (i.match(/^https?:\/\//)) {
-                    base = i.replace('data.json', '');
+                    if (!base) {
+                        base = i.replace('data.json', '');
+                    }
                     Y.use('io-base', stack.add(function () {
                         Y.log('Fetching: ' + i, 'info', 'builder');
                         Y.io(i, {
@@ -419,7 +425,9 @@ YUI.add('doc-builder', function (Y) {
                         });
                     }));
                 } else {
-                    base = path.dirname(path.resolve(i));
+                    if (!base) {
+                        base = path.dirname(path.resolve(i));
+                    }
                     var data = Y.Files.getJSON(i);
                     data.base = base;
                     //self.options.externalData = Y.mix(self.options.externalData || {}, data);


### PR DESCRIPTION
This commit addressed issue #237 and adds the ability to specify a base url for a given data.json to be
used when constructing urls for external links. For example:

``` json
  "external": {
    "data": [
      {
        "base": "http://emberjs.com/api/",
        "json": "http://builds.emberjs.com/tags/v1.5.1/ember-docs.json"
      },
      {
        "base": "http://emberjs.com/api/",
        "json": "http://builds.emberjs.com/tags/v1.0.0-beta.6/ember-data-docs.json"
      }
    ]
  }
```

This is not breaking. For example, the following is still valid:

``` json
  "external": {
    "data": [
      "http://builds.emberjs.com/tags/v1.5.1/ember-docs.json"
    ]
  }
```
