### PR TITLE
Making REGEX_OPTIONAL greedy

### DIFF
--- a/lib/docparser.js
+++ b/lib/docparser.js
@@ -64,7 +64,7 @@ YUI.add('docparser', function (Y) {
 
         REGEX_TYPE = /(.*?)\{(.*?)\}(.*)/,
         REGEX_FIRSTWORD = /^\s*?([^\s]+)(.*)/,
-        REGEX_OPTIONAL = /\[(.*?)\]/,
+        REGEX_OPTIONAL = /^\[(.*)\]$/,
         REGEX_START_COMMENT = {
             js: /^\s*\/\*\*/,
             coffee: /^\s*###\*/


### PR DESCRIPTION
Allows for arrays in default values for optional arguments. E.g., `@param {Array} [arr=[]]`. The current version would leave out the closing bracket.
