### PR TITLE
Bump marked version to ^0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,101 +1,138 @@
 {
-    "name": "yuidocjs",
-    "version": "0.3.50",
-    "description": "YUIDoc, YUI's JavaScript Documentation engine.",
-    "author": "Dav Glass <davglass@gmail.com>",
-    "bugs": { "url" : "http://github.com/yui/yuidoc/issues" },
-    "contributors": [
-        { "name": "Adam Moore", "email": "amoore@gmail.com" },
-        { "name": "Ryan Grove", "email": "ryan@wonko.com" },
-        { "name": "Eric Ferraiuolo", "email": "eferraiuolo@gmail.com" },
-        { "name": "Felipe Gasper", "email": "felipe@cpanel.net" },
-        { "name": "Evan Goer", "email": "evan@goer.org" },
-        { "name": "Alberto Gragera", "email": "albgra@gmail.com" },
-        { "name": "Pat Cavit", "email": "pcavit@gmail.com" },
-        { "name": "Kazuhito Hokamura", "email": "k.hokamura@gmail.com" },
-        { "name": "prodaea", "email": "rlee@etherealnation.net" },
-        { "name": "Wei Wang", "email": "weiwang85@gmail.com" },
-        { "name": "Thomas Boyt", "email": "me@thomasboyt.com" }
-    ],
-    "engines": {
-        "node" : ">=0.10.0"
+  "name": "yuidocjs",
+  "version": "0.3.50",
+  "description": "YUIDoc, YUI's JavaScript Documentation engine.",
+  "author": "Dav Glass <davglass@gmail.com>",
+  "bugs": {
+    "url": "http://github.com/yui/yuidoc/issues"
+  },
+  "contributors": [
+    {
+      "name": "Adam Moore",
+      "email": "amoore@gmail.com"
     },
-    "keywords": [
-        "yui",
-        "jsdoc",
-        "coffeescript",
-        "api",
-        "documentation",
-        "javadoc",
-        "docs",
-        "apidocs"
-    ],
-    "main": "./lib/index",
-    "bin" : { "yuidoc" : "./lib/cli.js" },
-    "dependencies": {
-        "yui": "3.14.1",
-        "rimraf": "2.x",
-        "marked": "~0.2.8",
-        "minimatch": "~0.2.11",
-        "graceful-fs": "2.x",
-        "express": "~3.1.2"
+    {
+      "name": "Ryan Grove",
+      "email": "ryan@wonko.com"
     },
-    "devDependencies": {
-        "jshint": "2.4.x",
-        "ytestrunner": "~0.3.3",
-        "yuitest": ">=0.7.3",
-        "selleck": "~0.1",
-        "istanbul": "0.2.x"
+    {
+      "name": "Eric Ferraiuolo",
+      "email": "eferraiuolo@gmail.com"
     },
-    "scripts": {
-        "pretest": "jshint ./lib/*.js ./tests/*.js",
-        "test": "istanbul cover --print=both --yui ytestrunner -- --include ./tests/options.js --include ./tests/builder.js --include ./tests/parser.js --include ./tests/parser_coffee.js --include ./tests/files.js --include ./tests/utils.js --include ./tests/preprocessor.js"
+    {
+      "name": "Felipe Gasper",
+      "email": "felipe@cpanel.net"
     },
-    "preferGlobal": "true",
-    "licenses":[
-        {
-            "type" : "BSD",
-            "url" : "https://github.com/yui/yuidoc/blob/master/LICENSE"
-        }
-    ],
-    "repository": {
-        "type":"git",
-        "url":"http://github.com/yui/yuidoc.git"
+    {
+      "name": "Evan Goer",
+      "email": "evan@goer.org"
     },
-    "jshintConfig": {
-        "bitwise"   : true,
-        "browser"   : true,
-        "curly"     : true,
-        "eqeqeq"    : true,
-        "forin"     : true,
-        "immed"     : true,
-        "latedef"   : "nofunc",
-        "laxbreak"  : true,
-        "maxerr"    : 500,
-        "maxlen"    : 150,
-        "newcap"    : true,
-        "noarg"     : true,
-        "node"      : true,
-        "noempty"   : true,
-        "onevar"    : true,
-        "trailing"  : true,
-        "undef"     : true,
-        "unused"    : "vars",
-        "yui"       : true
+    {
+      "name": "Alberto Gragera",
+      "email": "albgra@gmail.com"
     },
-    "yuidoc": {
-        "name": "YUIDoc",
-        "logo": "http://yuilibrary.com/img/yui-logo.png",
-        "options": {
-            "external": {
-                "data": "http://yuilibrary.com/yui/docs/api/data.json"
-            },
-            "linkNatives": "true",
-            "attributesEmit": "true",
-            "paths": [
-                "./lib"
-            ],
-            "outdir": "./output/api"
-        }
+    {
+      "name": "Pat Cavit",
+      "email": "pcavit@gmail.com"
+    },
+    {
+      "name": "Kazuhito Hokamura",
+      "email": "k.hokamura@gmail.com"
+    },
+    {
+      "name": "prodaea",
+      "email": "rlee@etherealnation.net"
+    },
+    {
+      "name": "Wei Wang",
+      "email": "weiwang85@gmail.com"
+    },
+    {
+      "name": "Thomas Boyt",
+      "email": "me@thomasboyt.com"
     }
+  ],
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "keywords": [
+    "yui",
+    "jsdoc",
+    "coffeescript",
+    "api",
+    "documentation",
+    "javadoc",
+    "docs",
+    "apidocs"
+  ],
+  "main": "./lib/index",
+  "bin": {
+    "yuidoc": "./lib/cli.js"
+  },
+  "dependencies": {
+    "express": "~3.1.2",
+    "graceful-fs": "2.x",
+    "marked": "^0.3.2",
+    "minimatch": "~0.2.11",
+    "rimraf": "2.x",
+    "yui": "3.14.1"
+  },
+  "devDependencies": {
+    "jshint": "2.4.x",
+    "ytestrunner": "~0.3.3",
+    "yuitest": ">=0.7.3",
+    "selleck": "~0.1",
+    "istanbul": "0.2.x"
+  },
+  "scripts": {
+    "pretest": "jshint ./lib/*.js ./tests/*.js",
+    "test": "istanbul cover --print=both --yui ytestrunner -- --include ./tests/options.js --include ./tests/builder.js --include ./tests/parser.js --include ./tests/parser_coffee.js --include ./tests/files.js --include ./tests/utils.js --include ./tests/preprocessor.js"
+  },
+  "preferGlobal": "true",
+  "licenses": [
+    {
+      "type": "BSD",
+      "url": "https://github.com/yui/yuidoc/blob/master/LICENSE"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/yui/yuidoc.git"
+  },
+  "jshintConfig": {
+    "bitwise": true,
+    "browser": true,
+    "curly": true,
+    "eqeqeq": true,
+    "forin": true,
+    "immed": true,
+    "latedef": "nofunc",
+    "laxbreak": true,
+    "maxerr": 500,
+    "maxlen": 150,
+    "newcap": true,
+    "noarg": true,
+    "node": true,
+    "noempty": true,
+    "onevar": true,
+    "trailing": true,
+    "undef": true,
+    "unused": "vars",
+    "yui": true
+  },
+  "yuidoc": {
+    "name": "YUIDoc",
+    "logo": "http://yuilibrary.com/img/yui-logo.png",
+    "options": {
+      "external": {
+        "data": "http://yuilibrary.com/yui/docs/api/data.json"
+      },
+      "linkNatives": "true",
+      "attributesEmit": "true",
+      "paths": [
+        "./lib"
+      ],
+      "outdir": "./output/api"
+    }
+  }
 }


### PR DESCRIPTION
It just updates marked version to ^0.3.2 since marked has security fixes.

The package.json seems to has many changes, but it actually only updates marked version by `npm install --save marked@latest`.

See also: https://nodesecurity.io/advisories/marked_multiple_content_injection_vulnerabilities
