### PR TITLE
Fix a wrong link in the syntax docs

### DIFF
--- a/docs/syntax/index.mustache
+++ b/docs/syntax/index.mustache
@@ -111,7 +111,7 @@ function IO (config) {
         In JavaScript, this is generally an object with a constructor function. 
         The value of `@class` should be the string that identifies the functional class on its parent object. 
         For example, the `@class` for `Y.DD.Drag` would be `Drag` 
-        (and its <a href="#@namespace">`@namespace`</a> would be `DD`).</p>
+        (and its <a href="#namespace">`@namespace`</a> would be `DD`).</p>
         
         <p>YUIDoc expects methods, properties, attributes, and events to belong to a class, 
         so in general you must provide at least one class for each module in your source tree. 


### PR DESCRIPTION
This issue was reported in #258, but we need to fix the docs of `master` branch instead of `gh-pages` branch.
