### PR TITLE
Adds support for `\*` in REGEX_LINE_HEAD_CHAR..

### DIFF
--- a/lib/docparser.js
+++ b/lib/docparser.js
@@ -75,7 +75,7 @@ YUI.add('docparser', function (Y) {
         },
         REGEX_LINE_HEAD_CHAR = {
             js: /^\s*\*/,
-            coffee: /^\s*#/
+            coffee: /^\s*[#\*]/
         },
         REGEX_LINES = /\r\n|\n/,
         REGEX_GLOBAL_LINES = /\r\n|\n/g,

--- a/tests/input/coffee/test2.coffee
+++ b/tests/input/coffee/test2.coffee
@@ -1,0 +1,12 @@
+
+###*
+ * The test project
+ * @project tester
+ * @title The Tester
+ * @icon http://a.img
+ * @url http://one.url
+ * @url http://two.url
+ * @author admo
+ * @contributor davglass
+ * @contributor entropy
+###


### PR DESCRIPTION
I've tweaked the regex to allow for more flexibility in coffeescript comments.
I'd really like to see this feature in the parser as it allows for easier interoperability with the Coffeescript syntax generated in Sublime Text using the DocBlockr plugin (https://github.com/spadgos/sublime-jsdocs)

One problem I'm having though is getting my test cases integrated. Any help with that would be very much appreciated.
