### PR TITLE
Fix for issue #288. v3.18.1 of yui was causing extra whitespace for inline code

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "marked": "^0.3.2",
     "minimatch": "^1.0.0",
     "rimraf": "2.x",
-    "yui": "^3.14.1"
+    "yui": "3.17.2"
   },
   "devDependencies": {
     "jshint": "2.4.x",


### PR DESCRIPTION
This is a fix for issue #288 

I spent a lot of time trying to narrow down the issue and it seems it has to do with the latest version of YUI.

0.4.0 was using YUI version 3.18.1 and this seemed to cause the regression. Previous YUI version of 3.18.0 also had the same problem, but 3.17.2 worked fine. So you will have to nuke your node_modules and reinstall to verify the fix.

I've ran the unit tests and there is no regression caused by downgrading the YUI version. I've also tested this against the global 'yuidoc' method to generate the docs as well as the node API to generate the docs and both works as intended. 

Any questions pls ask me and will be happy to help.

Note: My checkin comment was incorrect, I mentioned the wrong yui version. Sorry :( 
