### PR TITLE
Fixes indents of templates and bumps YUI dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "marked": "^0.3.2",
     "minimatch": "^1.0.0",
     "rimraf": "2.x",
-    "yui": "^3.14.1"
+    "yui": "^3.18.1"
   },
   "devDependencies": {
     "jshint": "2.4.x",

--- a/themes/default/layouts/main.handlebars
+++ b/themes/default/layouts/main.handlebars
@@ -36,7 +36,7 @@
             <div class="apidocs">
                 <div id="docs-main">
                     <div class="content">
-                        {{>layout_content}}
+{{>layout_content}}
                     </div>
                 </div>
             </div>

--- a/themes/default/layouts/xhr.handlebars
+++ b/themes/default/layouts/xhr.handlebars
@@ -1,6 +1,6 @@
 <div id="docs-main">
     <div class="content">
-        {{>layout_content}}
+{{>layout_content}}
     </div>
 </div>
 


### PR DESCRIPTION
This PR fixes #288. This problem is due to `Y.Handlebars` have been upgraded from v1.x to v2.0.0 since YUI 3.18.0.

Handlebars v2.0.0 have been changed the handling of indents to matches to the Mustache specs.
https://github.com/wycats/handlebars.js/blob/master/release-notes.md

Therefore, it fixes indents of templates and I'd like to make clear YUIDoc uses Handlebars v2.0.0 by depending on YUI 3.18.1 or later.
