### PR TITLE
Use res.status(status).send(body) instead of res.send(body, status)

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -98,7 +98,7 @@ YUI.add('server', function (Y) {
                     }
 
 
-                    res.send(html.join('\n'), 404);
+                    res.status(404).send(html.join('\n'));
                 });
 
             },


### PR DESCRIPTION
YUIDoc is using `res.send(body, status)` method of Express, but it have been deprecated since Express 4.7.0, and it returns following warning for now. It should use `res.status(status).send(body)` instead.

```
express deprecated res.send(body, status): Use res.status(status).send(body) instead
```

See also: https://github.com/strongloop/express/blob/master/History.md#470--2014-07-25