### PR TITLE
Fix a bug with parse files written in CR newline (fixes #96)

### DIFF
--- a/lib/yuidoc.js
+++ b/lib/yuidoc.js
@@ -211,7 +211,7 @@ YUI.add('yuidoc', function (Y) {
                             self.filecount++;
                             text = fs.readFileSync(fullpath, Y.charset);
 
-                            self.filemap[fullpath] = text;
+                            self.filemap[fullpath] = text.replace(/\r?\n|\r/g, '\n');
                             self.dirmap[fullpath] = dir;
                             self.getSelleck(fullpath);
 


### PR DESCRIPTION
It fixes #96. It doesn't have test code by design because mixed newline files in a repository cause confusion.