### PR TITLE
Fix a bug with "@" doesn't escapable in example

### DIFF
--- a/lib/docparser.js
+++ b/lib/docparser.js
@@ -172,6 +172,18 @@ YUI.add('docparser', function (Y) {
         ],
 
         /**
+         * A list of ignored tags. These tags should be ignored because there is
+         * likely to be used for purposes other than JSDoc tags in JavaScript comments.
+         * @property IGNORE_TAGLIST
+         * @type Array
+         * @final
+         * @for DocParser
+         */
+        IGNORE_TAGLIST = [
+            "media"
+        ],
+
+        /**
          * Common errors will get scrubbed instead of being ignored.
          * @property CORRECTIONS
          * @type Object
@@ -1128,6 +1140,7 @@ YUI.add('docparser', function (Y) {
             var lines = comment.split(REGEX_LINES),
                 len = lines.length,
                 i,
+                regex,
                 parts, part, peek, skip,
                 tag, value,
                 results = [{
@@ -1150,7 +1163,8 @@ YUI.add('docparser', function (Y) {
 
             // reconsitute and tokenize the comment block
             comment = this.unindent(lines.join('\n'));
-            parts = comment.split(/(?:^|\n)\s*(@\w*)/);
+            regex = new RegExp('(?:^|\\n)\\s*((?!@' + IGNORE_TAGLIST.join(')(?!@') + ')@\\w*)');
+            parts = comment.split(regex);
             len = parts.length;
             for (i = 0; i < len; i++) {
                 value = '';

--- a/tests/input/test/test.js
+++ b/tests/input/test/test.js
@@ -159,6 +159,13 @@ This is the description
 **/
 
 /**
+@method foo2
+@example
+    @media screen and (max-width: 767px) {
+    }
+*/
+
+/**
 Other Class
 @class OtherClass
 @extensionfor myclass

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -440,6 +440,10 @@ suite.add(new YUITest.TestCase({
         Assert.areSame(item.params[0].props[0].name, 'name');
         Assert.isTrue(item.params[0].props[0].optional);
 
+    },
+    'test: markdown example': function () {
+        var item = this.findByName('foo2', 'myclass');
+        Assert.areSame(item.example[0], '\n    @media screen and (max-width: 767px) {\n    }');
     }
 }));
 


### PR DESCRIPTION
The issue due to non JSDoc tags such as `@media` recognized as JSDoc tags.
It avoid the problem by ignoring tags of the target.

Fix #179.