### PR TITLE
Change the Markdown parser

### DIFF
--- a/docs/args/index.mustache
+++ b/docs/args/index.mustache
@@ -261,8 +261,8 @@ See below for <a href="#ex-yui3">more</a> <a href="#ex-yuidoc">examples</a>.
 <tr>
     <td>`markdown`</td>
     <td>
-        Options to pass to Marked, the Markdown compiler used to compile API descriptions. 
-        See the <a href="https://github.com/chjj/marked#options">Marked readme</a> for details.
+        Options to pass to markdown-it, the Markdown compiler used to compile API descriptions.
+        See the <a href="https://markdown-it.github.io/markdown-it/#MarkdownIt.new">markdown-it API</a> for details.
     </td>
 </tr>
 </table>

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -54,7 +54,7 @@ YUI.add('doc-builder', function (Y) {
         if (options.themedir) {
             themeDir = options.themedir;
         }
-
+        this.md = new MarkdownIt(options.markdown);
         this.data = data;
         Y.log('Building..', 'info', 'builder');
         this.files = 0;
@@ -142,8 +142,7 @@ YUI.add('doc-builder', function (Y) {
          * @return {HTML} The rendered HTML
          */
         markdown: function (data) {
-            var md = new MarkdownIt(this.options.markdown);
-            var html = md.render(data);
+            var html = this.md.render(data);
             //Only reprocess if helpers were asked for
             if (this.options.helpers || (html.indexOf('{{#crossLink') > -1)) {
                 try {

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -3,7 +3,7 @@
  * Code licensed under the BSD License:
  * https://github.com/yui/yuidoc/blob/master/LICENSE
  */
-var marked = require('marked'),
+var MarkdownIt = require('markdown-it'),
     fs = require('graceful-fs'),
     noop = function () {},
     path = require('path'),
@@ -138,16 +138,16 @@ YUI.add('doc-builder', function (Y) {
          * Wrapper around the Markdown parser so it can be normalized or even side stepped
          * @method markdown
          * @private
-         * @param {String} md The Markdown string to parse
+         * @param {String} data The Markdown string to parse
          * @return {HTML} The rendered HTML
          */
-        markdown: function (md) {
-            var html = marked(md, this.options.markdown);
+        markdown: function (data) {
+            var md = new MarkdownIt(this.options.markdown);
+            var html = md.render(data);
             //Only reprocess if helpers were asked for
             if (this.options.helpers || (html.indexOf('{{#crossLink') > -1)) {
-                //console.log('MD: ', html);
                 try {
-                    // marked auto-escapes quotation marks (and unfortunately
+                    // markdown-it auto-escapes quotation marks (and unfortunately
                     // does not expose the escaping function)
                     html = html.replace(/&quot;/g, "\"");
                     html = (Y.Handlebars.compile(html))({});
@@ -156,7 +156,6 @@ YUI.add('doc-builder', function (Y) {
                     html = html.replace(/\\{/g, '{').replace(/\\}/g, '}');
                     Y.log('Failed to parse Handlebars, probably an unknown helper, skipping..', 'warn', 'builder');
                 }
-                //console.log('HB: ', html);
             }
             return html;
         },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "express": "^4.10.1",
     "graceful-fs": "2.x",
-    "marked": "^0.3.3",
+    "markdown-it": "^3.0.7",
     "minimatch": "^2.0.1",
     "rimraf": "2.x",
     "yui": "^3.18.1"


### PR DESCRIPTION
It changes the Markdown parser from marked to markdown-it.

Potential security issues have been reported to the marked, but there is no plan to still be fixed. Because YUIDoc is an one of the development tool, I have thought unlikely to be affected by the problem. However, marked is no longer actively maintained, and I'd like to choice a parser that are more maintenance.

Since YUIDoc only have utilized simply marked as a simple Markdown parser, change can often be reduced.

/cc @juandopazo @caridy 