### PR TITLE
Bump markdown-it version to ^4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "express": "^4.10.1",
     "graceful-fs": "2.x",
-    "markdown-it": "^3.0.7",
+    "markdown-it": "^4.0.1",
     "minimatch": "^2.0.1",
     "rimraf": "2.x",
     "yui": "^3.18.1"


### PR DESCRIPTION
We're not using any markdown-it plugins, so we don't need to change our source code in YUIDoc.