### PR TITLE
Use logFn configuration to logging (fixes #325)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,6 +40,11 @@ function log (message, level) {
     if (!message || !level || typeof console[level] !== 'function') {
         return;
     }
+
+    if (typeof message === 'object') {
+        message = JSON.stringify(message);
+    }
+
     console[level]('%s: %s', level, message);
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,6 +36,12 @@ var YUI = require('yui' + (debug ? '/debug' : '')).YUI,
     fs = require('graceful-fs'),
     metaPath = path.join(__dirname, '../', 'package.json');
 
+function log (message, level) {
+    if (!message || !level || typeof console[level] !== 'function') {
+        return;
+    }
+    console[level]('%s: %s', level, message);
+}
 
 process.on('uncaughtException', function (msg) {
     var meta = JSON.parse(fs.readFileSync(metaPath)),
@@ -44,6 +50,7 @@ process.on('uncaughtException', function (msg) {
 
     inst.applyConfig({
         debug: true,
+        logFn: log,
         useColor: useColor
     });
 
@@ -100,6 +107,7 @@ var Y = YUI({
         attribute: true,
         handlebars: true
     },
+    logFn: log,
     useSync: true
 }).use('utils', 'docparser', 'yuidoc', 'doc-builder', 'docview', 'files', 'help', 'options', 'server', 'project');
 


### PR DESCRIPTION
`util.error` have been deprecated on Node v0.12, but YUI still uses it. It uses `logFn` configuration of YUI to avoid this problem. Basically, it'll uses `console.*` functions instead.

Fix #325.