### PR TITLE
Fix a bug that inherited class was parsed twice (fixes #324)

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -665,11 +665,10 @@ YUI.add('doc-builder', function (Y) {
                         }
                         if (!a.description) {
                             a.description = ' ';
-                        } else {
-                            //a.description = markdown(a.description, true, self.defaultTags);
+                        } else if (!o.extended_from) {
                             a.description = self.markdown(a.description);
                         }
-                        if (a.example) {
+                        if (a.example && !o.extended_from) {
                             a.example = self.markdown(a.example);
                         }
                         a = self.addFoundAt(a);
@@ -697,7 +696,7 @@ YUI.add('doc-builder', function (Y) {
                         }
                     });
                 } else if (k1 === 'description' || k1 === 'example') {
-                    o[k1] = self.markdown(i);
+                    o[k1] = o.extended_from ? i : self.markdown(i);
                 }
             });
             return o;
@@ -1211,7 +1210,6 @@ YUI.add('doc-builder', function (Y) {
                                 i.paramsList.push(name);
                             });
                         }
-                        //i.methodDescription = self._parseCode(markdown(i.description || ''));
                         i.methodDescription = self._parseCode(i.description);
                         if (i.example && i.example.length) {
                             if (i.example.forEach) {
@@ -1220,7 +1218,7 @@ YUI.add('doc-builder', function (Y) {
                                     e += self._parseCode(self.markdown(v));
                                 });
                                 i.example = e;
-                            } else {
+                            } else if (!i.extended_from) {
                                 i.example = self._parseCode(self.markdown(i.example));
                             }
                         }


### PR DESCRIPTION
All descriptions and examples of inherited classes was parsed markdown by markdown-it twice. This fixes #324.