### PR TITLE
Fix @returns tag of extended classes doesn't escape HTML (fixes #324)

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -691,7 +691,7 @@ YUI.add('doc-builder', function (Y) {
                             if (v.forEach || (v instanceof Object)) {
                                 o[k1][k] = self.augmentData(v);
                             } else {
-                                o[k1][k] = self.markdown(v);
+                                o[k1][k] = o.extended_from ? v : self.markdown(v);
                             }
                         }
                     });


### PR DESCRIPTION
This is an additional fixes #324. See also #341.