### PR TITLE
Drop removed JSHint rules

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -17,8 +17,6 @@ based templates to generate static HTML content
 */
 
 YUI.add('doc-builder', function (Y) {
-    /*jshint onevar:false */
-
     var fixType = Y.Lang.fixType,
         print = function (items) {
             var out = '<ul>';

--- a/lib/options.js
+++ b/lib/options.js
@@ -20,8 +20,6 @@ YUI.add('options', function (Y) {
      * @return {Object} The config object
      */
     Y.Options = function (args) {
-        /*jshint onevar:false */
-
         var options = {
             port: 3000,
             nocode: false

--- a/lib/project.js
+++ b/lib/project.js
@@ -53,7 +53,6 @@ YUI.add('project', function (Y) {
             }
 
             if (typeof options.tabtospace === 'number') {
-                /*jshint onevar:false */
                 options.tabspace = '';
                 for (var s = 0; s < options.tabtospace; s++) {
                     options.tabspace += ' ';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,6 @@
  * Code licensed under the BSD License:
  * https://github.com/yui/yuidoc/blob/master/LICENSE
  */
-/*jshint onevar:false */
 var path = require('path'),
     minimatch = require('minimatch'),
     fs = require('graceful-fs');

--- a/package.json
+++ b/package.json
@@ -114,8 +114,6 @@
     "noarg": true,
     "node": true,
     "noempty": true,
-    "onevar": true,
-    "trailing": true,
     "undef": true,
     "unused": "vars",
     "yui": true


### PR DESCRIPTION
The `onevar` and `trailing` rules at JSHint have been removed. I'm not sure we
should use JSCS for now, but these rules doesn't works anymore.