### PR TITLE
Switch to true Markdown options as default (fixes #344)

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -17,6 +17,11 @@ based templates to generate static HTML content
 */
 
 YUI.add('doc-builder', function (Y) {
+    var defaultMarkdownOption = {
+        html: true,
+        linkify: true
+    };
+
     var fixType = Y.Lang.fixType,
         print = function (items) {
             var out = '<ul>';
@@ -52,7 +57,7 @@ YUI.add('doc-builder', function (Y) {
         if (options.themedir) {
             themeDir = options.themedir;
         }
-        this.md = new MarkdownIt(options.markdown);
+        this.md = new MarkdownIt(Y.merge(defaultMarkdownOption, options.markdown));
         this.data = data;
         Y.log('Building..', 'info', 'builder');
         this.files = 0;


### PR DESCRIPTION
It turns to `true` the `html` and `linkify` options of `markdown-it`.
This is more similar behavior with the previous Markdown parser. Fixes #344.