### PR TITLE
Use SPDX license Identifier in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,12 +89,7 @@
     "test": "istanbul cover --print=both --yui ytestrunner -- --include ./tests/options.js --include ./tests/builder.js --include ./tests/parser.js --include ./tests/parser_coffee.js --include ./tests/files.js --include ./tests/utils.js --include ./tests/preprocessor.js"
   },
   "preferGlobal": "true",
-  "licenses": [
-    {
-      "type": "BSD",
-      "url": "https://github.com/yui/yuidoc/blob/master/LICENSE"
-    }
-  ],
+  "licenses": "BSD-3-Clause",
   "repository": {
     "type": "git",
     "url": "http://github.com/yui/yuidoc.git"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "test": "istanbul cover --print=both --yui ytestrunner -- --include ./tests/options.js --include ./tests/builder.js --include ./tests/parser.js --include ./tests/parser_coffee.js --include ./tests/files.js --include ./tests/utils.js --include ./tests/preprocessor.js"
   },
   "preferGlobal": "true",
-  "licenses": "BSD-3-Clause",
+  "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
     "url": "http://github.com/yui/yuidoc.git"


### PR DESCRIPTION
npm changed to use SPDX to validates the license of npm modules.

* https://github.com/npm/npm/pull/8197
* http://spdx.org/licenses/