### PR TITLE
Import utility script for MDN links

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -7,6 +7,7 @@
 
 var MarkdownIt = require('markdown-it');
 var fs = require('graceful-fs');
+var mdn = require('mdn-links');
 var noop = function () {};
 var path = require('path');
 var TEMPLATE;
@@ -251,13 +252,11 @@ YUI.add('doc-builder', function (Y) {
                 }
             }
             if (!link && self.options.linkNatives) {
-                if (self.NATIVES && self.NATIVES[item]) {
-                    href = self.NATIVES_LINKER(item);
-                    if (href) {
-                        className += ' external';
-                        newWin = true;
-                        link = true;
-                    }
+                href = mdn.getLink.apply(mdn, item.split('/'));
+                if (href) {
+                    className += ' external';
+                    newWin = true;
+                    link = true;
                 }
             }
             if (link) {
@@ -271,59 +270,7 @@ YUI.add('doc-builder', function (Y) {
             }
             return (raw) ? href : item;
         },
-        /**
-         * List of native types to cross link to MDN
-         * @property NATIVES
-         * @type Object
-         */
-        NATIVES: {
-            'Array': 1,
-            'Boolean': 1,
-            'Date': 1,
-            'decodeURI': 1,
-            'decodeURIComponent': 1,
-            'encodeURI': 1,
-            'encodeURIComponent': 1,
-            'eval': 1,
-            'Error': 1,
-            'EvalError': 1,
-            'Function': 1,
-            'Infinity': 1,
-            'isFinite': 1,
-            'isNaN': 1,
-            'Math': 1,
-            'NaN': 1,
-            'Number': 1,
-            'Object': 1,
-            'parseFloat': 1,
-            'parseInt': 1,
-            'RangeError': 1,
-            'ReferenceError': 1,
-            'RegExp': 1,
-            'String': 1,
-            'SyntaxError': 1,
-            'TypeError': 1,
-            'undefined': 1,
-            'URIError': 1,
-            'HTMLElement': 'https:/' + '/developer.mozilla.org/en/Document_Object_Model_(DOM)/',
-            'HTMLCollection': 'https:/' + '/developer.mozilla.org/en/Document_Object_Model_(DOM)/',
-            'DocumentFragment': 'https:/' + '/developer.mozilla.org/en/Document_Object_Model_(DOM)/',
-            'HTMLDocument': 'https:/' + '/developer.mozilla.org/en/Document_Object_Model_(DOM)/'
-        },
-        /**
-         * Function to link an external type uses `NATIVES` object
-         * @method NATIVES_LINKER
-         * @private
-         * @param {String} name The name of the type to link
-         * @return {String} The combined URL
-         */
-        NATIVES_LINKER: function (name) {
-            var url = 'https:/' + '/developer.mozilla.org/en/JavaScript/Reference/Global_Objects/';
-            if (this.NATIVES[name] !== 1) {
-                url = this.NATIVES[name];
-            }
-            return url + name;
-        },
+
         /**
          * Mixes the various external data soures together into the local data, augmenting
          * it with flags.

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "express": "^4.13.0",
     "graceful-fs": "^4.1.2",
     "markdown-it": "^4.2.2",
+    "mdn-links": "^0.1.0",
     "minimatch": "^2.0.8",
     "rimraf": "2.x",
     "yui": "^3.18.1"


### PR DESCRIPTION
Implements #354.  A utility script is provided to update the native links, which can then be committed to the repo.  In the future, this could be improved to update the links at compile time so that they are always fresh.