### PR TITLE
Upgrade to faster, container-based builds on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ node_js:
     - "0.10"
     - "0.12"
     - "iojs"
+sudo: false


### PR DESCRIPTION
Added `sude: false` into `.travis.yml` as documented in [the migration guide](http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade) to opt in to the new, container-based, faster builds.