### PR TITLE
Bump eslint version to ^1.1.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,16 +2,12 @@
   "env": {
     "node": true
   },
+  "extends": "eslint:recommended",
   "globals": {
     "YUI": true
   },
   "rules": {
-    "camelcase": 0,
-    "new-cap": 0,
-    "no-loop-func": 0,
-    "no-process-exit": 0,
-    "no-underscore-dangle": 0,
-    "no-use-before-define": 0,
+    "no-console": 0,
     "quotes": [2, "single"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "yui": "^3.18.1"
   },
   "devDependencies": {
-    "eslint": "^1.0.0-rc-1",
+    "eslint": "^1.1.0",
     "istanbul": "^0.3.16",
     "selleck": "^0.1.18",
     "ytestrunner": "^0.3.3",


### PR DESCRIPTION
* Conform default recommended rules called "eslint:recommended"
* Currently turn off "no-console" rule

See also: http://eslint.org/docs/user-guide/migrating-to-1.0.0