### PR TITLE
Travis CI testing on Node v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: node_js
 node_js:
     - "0.10"
     - "0.12"
-    - "iojs"
+    - "4"
 sudo: false


### PR DESCRIPTION
It changes to testing on Node v4 instead of io.js.