### PR TITLE
add null check

### DIFF
--- a/themes/default/assets/js/api-filter.js
+++ b/themes/default/assets/js/api-filter.js
@@ -40,8 +40,10 @@ Y.APIFilter = Y.Base.create('apiFilter', Y.Base, [Y.AutoCompleteBase], {
                     var data = Y.YUIDoc.meta[self.get('queryType')],
                         out = [];
                     Y.each(data, function(v) {
-                        if (v.toLowerCase().indexOf(q.toLowerCase()) > -1) {
-                            out.push(v);
+                        if (v != null) {
+                            if (v.toLowerCase().indexOf(q.toLowerCase()) > -1) {
+                                out.push(v);
+                            }
                         }
                     });
                     return out;


### PR DESCRIPTION
The reason for adding this null check is that sometimes, for eg. in case of building yuidoc for https://github.com/photonstorm/phaser, when you try to toggle from 'classes' panel to 'modules' panel, the following error is being thrown -:

```Uncaught TypeError: Cannot read property 'toLowerCase' of null```.

For catching this error, I think adding a null check would be a good solution. Although I think, there might be some other reason which is leading to the error in the above case. Please check this. For your reference, version of my yuidoc is 0.9.0 .