### PR TITLE
when failing to parse markup, log...

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -161,6 +161,8 @@ YUI.add('doc-builder', function (Y) {
                     //Remove all the extra escapes
                     html = html.replace(/\\{/g, '{').replace(/\\}/g, '}');
                     Y.log('Failed to parse Handlebars, probably an unknown helper, skipping..', 'warn', 'builder');
+                    var debugstr = data.replace(/^/mg, '      ');
+                    console.log('\n'+debugstr + '\n');
                 }
             }
             return html;


### PR DESCRIPTION
...the markup that failed to parse, thus affording the user of the tool
a reasonable opportunity to fix the offending markup even if they have
made (much) more than a single edit to the documentation since last
running the tool.