### PR TITLE
[FIX] loosen node-back first-arg check to match node conventions

### DIFF
--- a/tests/files.js
+++ b/tests/files.js
@@ -170,8 +170,9 @@ suite.add(new YUITest.TestCase({
     'test: readFile': function () {
         var test = this;
         Y.Files.readFile('input/test/test.js', 'utf8', function (err) {
+
             test.resume(function () {
-                Assert.isNull(err);
+                Assert.isFalse(!!err);
             });
         });
         test.wait(100);


### PR DESCRIPTION
first argument is either:

* falsey: success scenario
* truthy: failure scenario, and the value may be the error