### PR TITLE
Adding a  method to the handlebars helpers

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -98,6 +98,19 @@ YUI.add('doc-builder', function (Y) {
             return str;
         });
 
+        Y.Handlebars.registerHelper('crossLinkElement', function (item, helperOptions) {
+            var str = item;
+            if (self.data.element[item]) {
+                var content = helperOptions.fn(this);
+                if (content === '') {
+                    content = item;
+                }
+                str = '<a href="../element/' + item.replace(/\//g, '_') +
+                    '.html">' + content + '</a>';
+            }
+            return str;
+        });
+
         Y.Handlebars.registerHelper('crossLinkRaw', function (item) {
             var str = '';
             if (!item) {

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -180,7 +180,7 @@ YUI.add('doc-builder', function (Y) {
                 base = '../',
                 baseItem,
                 newWin = false,
-                group = /(&lt;|<).*(?=&gt;$|>$)/.test(item) ? 'elements' : 'classes',
+                group = /(&lt;|<).*(?=(&gt;$|>$))/.test(item) ? 'elements' : 'classes',
                 className = 'crosslink';
 
             if (group === 'classes') {
@@ -289,7 +289,7 @@ YUI.add('doc-builder', function (Y) {
                 if (!content) {
                     content = baseItem;
                 }
-                item = '<a href="' + href + '" class="' + className + '"' + ((newWin) ? ' target="_blank"' : '') + '>' + content + '</a>';
+                item = '<a href="' + href + '" class="' + className + '"' + ((newWin) ? ' target="_blank"' : '') + '>' + content.replace('<', '&lt;').replace('>', '&gt;') + '</a>';
             }
             return (raw) ? href : item;
         },

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -98,19 +98,6 @@ YUI.add('doc-builder', function (Y) {
             return str;
         });
 
-        Y.Handlebars.registerHelper('crossLinkElement', function (item, helperOptions) {
-            var str = item;
-            if (self.data.element[item]) {
-                var content = helperOptions.fn(this);
-                if (content === '') {
-                    content = item;
-                }
-                str = '<a href="../element/' + item.replace(/\//g, '_') +
-                    '.html">' + content + '</a>';
-            }
-            return str;
-        });
-
         Y.Handlebars.registerHelper('crossLinkRaw', function (item) {
             var str = '';
             if (!item) {
@@ -193,7 +180,7 @@ YUI.add('doc-builder', function (Y) {
                 base = '../',
                 baseItem,
                 newWin = false,
-                group = /&lt;.*(?=&gt;$)/.test(item) ? 'elements' : 'classes',
+                group = /(&lt;|<).*(?=&gt;$|>$)/.test(item) ? 'elements' : 'classes',
                 className = 'crosslink';
 
             if (group === 'classes') {
@@ -202,7 +189,7 @@ YUI.add('doc-builder', function (Y) {
 
             item = baseItem = Y.Lang.trim(item.replace('{', '').replace('}', ''));
             //Remove Cruft
-            item = item.replace('*', '').replace('[', '').replace(']', '').replace('&lt;', '').replace('&gt;', '');
+            item = item.replace('*', '').replace('[', '').replace(']', '').replace('&lt;', '').replace('<', '').replace('&gt;', '').replace('>', '');
 
             var link = false,
                 href;

--- a/tests/builder.js
+++ b/tests/builder.js
@@ -175,6 +175,10 @@ suite.add(new YUITest.TestCase({
             Assert.isObject(method, 'Failed to find inherited method');
             Assert.isTrue((method.description.indexOf('DAVGLASS_WAS_HERE::Foo') > 0), 'Helper failed to parse');
         }, item);
+
+        suite.builder.renderElement(function(html) {
+            Assert.isTrue(/Element 3 <a.*?href=".*?elements\/x-foo.*>[^<]/.test(html), 'Failed to parse unescaped custom html element string');
+        }, suite.data.elements['x-baz'])
     },
 
     'test: markdown options': function () {

--- a/tests/builder.js
+++ b/tests/builder.js
@@ -178,7 +178,7 @@ suite.add(new YUITest.TestCase({
 
         suite.builder.renderElement(function(html) {
             Assert.isTrue(/Element 3 <a.*?href=".*?elements\/x-foo.*>[^<]/.test(html), 'Failed to parse unescaped custom html element string');
-        }, suite.data.elements['x-baz'])
+        }, suite.data.elements['x-baz']);
     },
 
     'test: markdown options': function () {

--- a/tests/input/test/test.js
+++ b/tests/input/test/test.js
@@ -256,7 +256,7 @@ Test `\{{foobar3\}}` `\{{barfoo3\}}`
 */
 
 /**
- * Element 3
+ * Element 3 {{#crossLink "<x-foo>"}}{{/crossLink}}
  *
  * @element x-baz
  * @parents <body>, <x-foo>
@@ -267,6 +267,7 @@ Test `\{{foobar3\}}` `\{{barfoo3\}}`
  * @attribute second    second attribute
  *                      test
  */
+
 
 /**
  * third

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -206,7 +206,7 @@ suite.add(new YUITest.TestCase({
 
         Assert.isObject(baz, 'Failed to find <x-baz> element');
         Assert.areSame('x-baz', baz.name, 'Failed to set name');
-        Assert.areSame('Element 3', baz.description, 'Failed to set description');
+        Assert.areSame('Element 3 {{#crossLink "<x-foo>"}}{{/crossLink}}', baz.description, 'Failed to set description');
         Assert.areSame('<body>, <x-foo>', baz.parents, 'Failed to set parents');
         Assert.areSame('<x-bar>', baz.contents, 'Failed to set contents');
         Assert.areSame('XBazElement', baz.interface, 'Failed to set interface');


### PR DESCRIPTION
to be able to handle unescaped '<' and '>' tags which occassionally come through
