### PR TITLE
Fix "--lint" option

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -35,7 +35,7 @@ if (options.server) {
 } else {
     var json = (new Y.YUIDoc(options)).run();
     if (json === null) {
-        throw new Error('Running YUIDoc returns null.');
+        return;
     }
     options = Y.Project.mix(json, options);
 


### PR DESCRIPTION
This PR fixes the `--lint` CLI option by reverting back to the behavior before https://github.com/yui/yuidoc/pull/348. This resolves https://github.com/yui/yuidoc/issues/403.

/cc @stefanpenner 