### PR TITLE
Fixed typo error

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -1170,7 +1170,7 @@ YUI.add('doc-builder', function (Y) {
                 if (data.uses) {
                     opts.meta.uses = data.uses;
                 }
-                if (data.entension_for && data.extension_for.length) {
+                if (data.extension_for && data.extension_for.length) {
                     opts.meta.extension_for = data.extension_for;
                 }
 

--- a/output/api/files/lib_builder.js.html
+++ b/output/api/files/lib_builder.js.html
@@ -1264,7 +1264,7 @@ YUI.add(&#x27;doc-builder&#x27;, function (Y) {
                 if (data.uses) {
                     opts.meta.uses = data.uses;
                 }
-                if (data.entension_for &amp;&amp; data.extension_for.length) {
+                if (data.extension_for &amp;&amp; data.extension_for.length) {
                     opts.meta.extension_for = data.extension_for;
                 }
 

--- a/tests/builder.js
+++ b/tests/builder.js
@@ -161,6 +161,15 @@ suite.add(new YUITest.TestCase({
             Assert.isObject(method.overwritten_from, 'Failed to find overwritten data');
         }, item);
     },
+    'test: extension_for': function() {
+      var item = suite.data.classes['mywidget.SubWidget'];
+      Assert.isObject(item, 'Failed to parse class');
+      suite.builder.renderClass(function (html, view, opts) {
+          var extension_for = opts.meta.extension_for;
+          Assert.isObject(extension_for, 'Failed to assign extension_for');
+          Assert.areSame(1, extension_for.length, 'Failed to assign extension_for');
+      }, item);
+    },
     'test: helper methods': function () {
         var item = suite.data.classes['mywidget.SuperWidget'];
         Assert.isObject(item, 'Failed to parse class');

--- a/tests/builder.js
+++ b/tests/builder.js
@@ -161,15 +161,6 @@ suite.add(new YUITest.TestCase({
             Assert.isObject(method.overwritten_from, 'Failed to find overwritten data');
         }, item);
     },
-    'test: extension_for': function() {
-      var item = suite.data.classes['mywidget.SubWidget'];
-      Assert.isObject(item, 'Failed to parse class');
-      suite.builder.renderClass(function (html, view, opts) {
-          var extension_for = opts.meta.extension_for;
-          Assert.isObject(extension_for, 'Failed to assign extension_for');
-          Assert.areSame(1, extension_for.length, 'Failed to assign extension_for');
-      }, item);
-    },
     'test: helper methods': function () {
         var item = suite.data.classes['mywidget.SuperWidget'];
         Assert.isObject(item, 'Failed to parse class');

--- a/tests/input/inherit/examplemodule.js
+++ b/tests/input/inherit/examplemodule.js
@@ -9,10 +9,10 @@
 
 YUI.add('examplemodule', function (Y) {
         Y.namespace('mywidget');
-
+        
         /**
          * <b>Superclass</b> description.<br>This is a second line too.
-         *
+         * 
          * @constructor
          * @class SuperWidget
          * @extends Widget
@@ -23,15 +23,15 @@ YUI.add('examplemodule', function (Y) {
          *
          */
         Y.mywidget.superwidget = Y.Base.create("mysuperwidget", Y.Widget, [], {
-
+                
                 /**
                  * <b>Supermethod</b> description.<br>This is a second line.
-                 *
+                 * 
                  * @method myMethod
                  * @async
                  */
                 myMethod: function () {}
-
+                
                 /**
                 * Overwritten method see {{#crossLink "mywidget.SuperWidget"}}{{/crossLink}}
                 * also see {{#crossLink "mywidget.SuperWidget/myMethod"}}{{/crossLink}}
@@ -83,37 +83,36 @@ YUI.add('examplemodule', function (Y) {
                 * Override Event
                 * @event init2
                 */
-
+                 
         }, {
-
+        
         });
-
+        
         /**
          * Subclass description.
-         *
+         * 
          * @constructor
          * @namespace mywidget
          * @class SubWidget
          * @extends mywidget.SuperWidget
-         * @extensionfor mywidget.SuperWidget
          */
         Y.mywidget.superwidget = Y.Base.create("mysuperwidget", Y.mywidget.superwidget, [], {
-
+                
                 /**
                  * Submethod description.
-                 *
+                 * 
                  * @method myMethod
                  * @param {boolean} d Foo
                  */
                 myMethod: function () {}
-
+                 
         }, {
-
+        
         });
 
         /**
          * Subclass description.
-         *
+         * 
          * @constructor
          * @namespace mywidget
          * @class SubWidget2

--- a/tests/input/inherit/examplemodule.js
+++ b/tests/input/inherit/examplemodule.js
@@ -9,10 +9,10 @@
 
 YUI.add('examplemodule', function (Y) {
         Y.namespace('mywidget');
-        
+
         /**
          * <b>Superclass</b> description.<br>This is a second line too.
-         * 
+         *
          * @constructor
          * @class SuperWidget
          * @extends Widget
@@ -23,15 +23,15 @@ YUI.add('examplemodule', function (Y) {
          *
          */
         Y.mywidget.superwidget = Y.Base.create("mysuperwidget", Y.Widget, [], {
-                
+
                 /**
                  * <b>Supermethod</b> description.<br>This is a second line.
-                 * 
+                 *
                  * @method myMethod
                  * @async
                  */
                 myMethod: function () {}
-                
+
                 /**
                 * Overwritten method see {{#crossLink "mywidget.SuperWidget"}}{{/crossLink}}
                 * also see {{#crossLink "mywidget.SuperWidget/myMethod"}}{{/crossLink}}
@@ -83,36 +83,37 @@ YUI.add('examplemodule', function (Y) {
                 * Override Event
                 * @event init2
                 */
-                 
+
         }, {
-        
-        });
-        
-        /**
-         * Subclass description.
-         * 
-         * @constructor
-         * @namespace mywidget
-         * @class SubWidget
-         * @extends mywidget.SuperWidget
-         */
-        Y.mywidget.superwidget = Y.Base.create("mysuperwidget", Y.mywidget.superwidget, [], {
-                
-                /**
-                 * Submethod description.
-                 * 
-                 * @method myMethod
-                 * @param {boolean} d Foo
-                 */
-                myMethod: function () {}
-                 
-        }, {
-        
+
         });
 
         /**
          * Subclass description.
-         * 
+         *
+         * @constructor
+         * @namespace mywidget
+         * @class SubWidget
+         * @extends mywidget.SuperWidget
+         * @extensionfor mywidget.SuperWidget
+         */
+        Y.mywidget.superwidget = Y.Base.create("mysuperwidget", Y.mywidget.superwidget, [], {
+
+                /**
+                 * Submethod description.
+                 *
+                 * @method myMethod
+                 * @param {boolean} d Foo
+                 */
+                myMethod: function () {}
+
+        }, {
+
+        });
+
+        /**
+         * Subclass description.
+         *
          * @constructor
          * @namespace mywidget
          * @class SubWidget2


### PR DESCRIPTION
`extension_for` blocks are never showing up. This is because there's a typo
error on `lib/builder.js`.

`entension_for` is wrong, replaced with `extension_for` instead.
