### PR TITLE
[FEATURE] Support setting 'projectAssets' in 'theme.json'

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -417,6 +417,14 @@ YUI.add('doc-builder', function (Y) {
                 cb();
             });
         },
+        _initialAssetsFolder: {
+            get: function(opts) {
+                if (this.__initialAssetsFolder === undefined) {
+                    this.__initialAssetsFolder = opts.meta.projectAssets || 'assets';
+                }
+                return this.__initialAssetsFolder;
+            }
+        },
         /**
          * File counter
          * @property files
@@ -718,7 +726,10 @@ YUI.add('doc-builder', function (Y) {
                     cbWriteRedirect();
                 });
             };
-            var defaultIndex = path.join(themeDir, 'assets', 'index.html');
+            var opts = self.getProjectMeta();
+            var assetsFolder = self._initialAssetsFolder.get.apply(self._initialAssetsFolder,
+                [opts]);
+            var defaultIndex = path.join(themeDir, assetsFolder, 'index.html');
             var stack = new Y.Parallel();
             Y.log('Making default directories: ' + dirs.join(','), 'info', 'builder');
             dirs.forEach(function (d) {
@@ -857,7 +868,7 @@ YUI.add('doc-builder', function (Y) {
                 }
                 opts.meta.title = self.data.project.name;
                 opts.meta.projectRoot = './';
-                opts.meta.projectAssets = './assets';
+                self.setAssetsFolder(opts, './');
                 opts.meta.projectLogo = self._resolveUrl(self.data.project.logo, opts);
                 opts = self.populateClasses(opts);
                 opts = self.populateElements(opts);
@@ -931,7 +942,7 @@ YUI.add('doc-builder', function (Y) {
                 opts.meta.line = data.line;
                 opts.meta = self.addFoundAt(opts.meta);
                 opts.meta.projectRoot = '../';
-                opts.meta.projectAssets = '../assets';
+                self.setAssetsFolder(opts, '../');
                 opts.meta.projectLogo = self._resolveUrl(self.data.project.logo, opts);
                 opts = self.populateClasses(opts);
                 opts = self.populateElements(opts);
@@ -1152,7 +1163,7 @@ YUI.add('doc-builder', function (Y) {
                 opts.meta.line = data.line;
                 opts.meta = self.addFoundAt(opts.meta);
                 opts.meta.projectRoot = '../';
-                opts.meta.projectAssets = '../assets';
+                self.setAssetsFolder(opts, '../');
                 opts.meta.projectLogo = self._resolveUrl(self.data.project.logo, opts);
 
                 opts = self.populateClasses(opts);
@@ -1444,7 +1455,7 @@ YUI.add('doc-builder', function (Y) {
                 opts.meta.line = data.line;
                 opts.meta = self.addFoundAt(opts.meta);
                 opts.meta.projectRoot = '../';
-                opts.meta.projectAssets = '../assets';
+                self.setAssetsFolder(opts, '../');
                 opts.meta.projectLogo = self._resolveUrl(self.data.project.logo, opts);
 
                 opts = self.populateClasses(opts);
@@ -1638,7 +1649,7 @@ YUI.add('doc-builder', function (Y) {
                 opts.meta.title = self.data.project.name;
                 opts.meta.moduleName = data.name;
                 opts.meta.projectRoot = '../';
-                opts.meta.projectAssets = '../assets';
+                self.setAssetsFolder(opts, '../')
                 opts.meta.projectLogo = self._resolveUrl(self.data.project.logo, opts);
 
                 opts = self.populateClasses(opts);
@@ -1747,14 +1758,17 @@ YUI.add('doc-builder', function (Y) {
             this.mixExternal(function () {
                 self.makeDirs(function () {
                     Y.log('Copying Assets', 'info', 'builder');
-                    if (!Y.Files.isDirectory(path.join(self.options.outdir, 'assets'))) {
-                        fs.mkdirSync(path.join(self.options.outdir, 'assets'), '0777');
+                    var opts = self.getProjectMeta();
+                    var assetsFolder = self._initialAssetsFolder.get.apply(self._initialAssetsFolder,
+                        [opts]);
+                    if (!Y.Files.isDirectory(path.join(self.options.outdir, assetsFolder))) {
+                        fs.mkdirSync(path.join(self.options.outdir, assetsFolder), '0777');
                     }
                     Y.Files.copyAssets([
                             path.join(DEFAULT_THEME, 'assets'),
-                            path.join(themeDir, 'assets')
+                            path.join(themeDir, assetsFolder)
                         ],
-                        path.join(self.options.outdir, 'assets'),
+                        path.join(self.options.outdir, assetsFolder),
                         false,
                         function () {
                             var cstack = new Y.Parallel();
@@ -1792,6 +1806,15 @@ YUI.add('doc-builder', function (Y) {
                         });
                 });
             });
+        },
+        setAssetsFolder: function(opts, prepend) {
+            this._initialAssetsFolder.get.apply(this._initialAssetsFolder,
+                [opts]);
+            if (opts.meta.projectAssets === undefined) {
+                opts.meta.projectAssets = prepend + 'assets';
+            } else {
+                opts.meta.projectAssets = prepend + opts.meta.projectAssets;
+            }
         }
     };
 });


### PR DESCRIPTION
This PR implements a change needed to alter custom theme `assets` folder name to something else.
The folder name itself in the input and output is mirrored so given `public` assets folder in the custom theme would result in having `public` assets folder in the compiled output with all the links inside files set properly.

To set the project assets folder one would need to have something like the following in his `theme.json` file:

```
{
    "yuiGridsUrl": "http://yui.yahooapis.com/3.9.1/build/cssgrids/cssgrids-min.css",
    "yuiSeedUrl": "http://yui.yahooapis.com/combo?3.9.1/build/yui/yui-min.js",
    "projectAssets": "public"
}
```