### PR TITLE
Travis build status badge as SVG

### DIFF
--- a/conf/docs/layouts/main.mustache
+++ b/conf/docs/layouts/main.mustache
@@ -46,7 +46,7 @@
                     </div>
 
                     <div class="bd">
-                        <a href="http://travis-ci.org/yui/yuidoc"><img src="https://secure.travis-ci.org/yui/yuidoc.png?branch=master" border="0"></a>
+                        <a href="http://travis-ci.org/yui/yuidoc"><img src="https://secure.travis-ci.org/yui/yuidoc.svg?branch=master" border="0"></a>
                     </div>
                 </div>
                 {{^hideTableOfContents}}


### PR DESCRIPTION
This trivial PR changes the PNG build status badge to a SVG build status badge.