### PR TITLE
CI building updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
-    - "0.10"
-    - "0.12"
-    - "4"
+- "4"
+- "6"
+- "7"
+matrix:
+  allow_failures:
+  - node_js: "7"
 sudo: false


### PR DESCRIPTION
* Add testing on Node.js v6
* Add testing on Node.js v7 with allow_failures flag
* Drop testing on Node.js v0.10 and v0.12